### PR TITLE
Audio source fixes

### DIFF
--- a/RPVoiceChat.csproj
+++ b/RPVoiceChat.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net462</TargetFramework>
-	  <LangVersion>9</LangVersion>
+    <TargetFramework>net462</TargetFramework>
+    <LangVersion>9</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
+    <RootNamespace>rpvoicechat</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
   "authors": [ "Ridderrasmus", "Purplep_", "blakdragan7" ],
   "contributors": [ "Dmitry221060" ],
   "description": "A mod that adds in game voice proximity chat!",
-  "version": "1.2.2"
+  "version": "1.2.3"
 }

--- a/src/Audio/AudioOutputManager.cs
+++ b/src/Audio/AudioOutputManager.cs
@@ -93,9 +93,9 @@ namespace rpvoicechat
 
         public void HandleLoopback(AudioPacket packet)
         {
-            if (!IsLoopbackEnabled)
-                return;
+            if (!IsLoopbackEnabled) return;
 
+            localPlayerAudioSource.UpdatePlayer();
             localPlayerAudioSource.QueueAudio(packet.AudioData, packet.Length);
         }
 

--- a/src/Audio/AudioOutputManager.cs
+++ b/src/Audio/AudioOutputManager.cs
@@ -86,6 +86,7 @@ namespace rpvoicechat
                 // Update the voice level if it has changed
                 if (source.voiceLevel != packet.VoiceLevel)
                     source.UpdateVoiceLevel(packet.VoiceLevel);
+                source.UpdatePlayer();
                 source.QueueAudio(packet.AudioData, packet.Length);
             });
         }

--- a/src/Audio/MicrophoneManager.cs
+++ b/src/Audio/MicrophoneManager.cs
@@ -97,24 +97,14 @@ namespace rpvoicechat
         public void UpdateCaptureAudioSamples(float deltaTime)
         {
             bool isMuted = config.IsMuted;
+            var clientEntity = capi.World.Player?.Entity;
 
-
-            if (!capi.World.Player.Entity.Alive || capi.World.Player.Entity.AnimManager.IsAnimationActive("sleep"))
-            {
+            if (isMuted || clientEntity == null || !clientEntity.Alive || clientEntity.AnimManager.IsAnimationActive("sleep"))
                 return;
-            }
-
-            if (isMuted)
-            {
-                return;
-            }
 
             int samplesAvailable = capture.AvailableSamples;
             int bufferLength = samplesAvailable * SampleToByte;
-            if (samplesAvailable <= 0)
-            {
-                return;
-            }
+            if (samplesAvailable <= 0) return;
 
             // because we would have to copy, its actually faster to just allocate each time here.
             var sampleBuffer = new byte[bufferLength];
@@ -147,7 +137,7 @@ namespace rpvoicechat
                     rms += sample*sample;
                 }
 
-                var calc = Math.Abs(Math.Sqrt(rms / numSamples));
+                var calc = Math.Sqrt(rms / numSamples);
                 if (double.IsNaN(calc)) calc = 0.000001;
                 Amplitude = calc;
 

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -97,8 +97,6 @@ namespace rpvoicechat
                 if (buffer == null)
                     return;
 
-                audioOutputManager.HandleLoopback(buffer, length);
-
                 AudioPacket packet = new AudioPacket()
                 {
                     PlayerId = capi.World.Player.PlayerUID,
@@ -106,6 +104,7 @@ namespace rpvoicechat
                     Length = length,
                     VoiceLevel = voiceLevel
                 };
+                audioOutputManager.HandleLoopback(packet);
                 client.SendAudioToServer(packet);
             };
 

--- a/src/Utils/LocationUtils.cs
+++ b/src/Utils/LocationUtils.cs
@@ -48,7 +48,17 @@ namespace rpvoicechat.Utils
         /// <param name="listenerPos">Listener's position object</param>
         public static Vec3f GetRelativeSpeakerLocation(EntityPos speakerPos, EntityPos listenerPos)
         {
-            var relativeSpeakerCoords = speakerPos.XYZFloat - listenerPos.XYZFloat;
+            return GetRelativeSpeakerLocation(speakerPos.XYZFloat, listenerPos);
+        }
+
+        /// <summary>
+        /// Returns speaker's position from listener's point of view
+        /// </summary>
+        /// <param name="speakerPos">Speaker's position</param>
+        /// <param name="listenerPos">Listener's position object</param>
+        public static Vec3f GetRelativeSpeakerLocation(Vec3f speakerPos, EntityPos listenerPos)
+        {
+            var relativeSpeakerCoords = speakerPos - listenerPos.XYZFloat;
             var listenerHeadAngle = listenerPos.Yaw + listenerPos.HeadYaw - Math.PI / 2;
             var cs = Math.Cos(listenerHeadAngle);
             var sn = Math.Sin(listenerHeadAngle);

--- a/src/Utils/LocationUtils.cs
+++ b/src/Utils/LocationUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
@@ -6,8 +7,13 @@ using Vintagestory.API.MathTools;
 
 namespace rpvoicechat.Utils
 {
+    using BlockEntry = Tuple<BlockPos, Block>;
+    using RayTraceResults = Tuple<List<Tuple<BlockPos, Block>>, List<Entity>>;
+
     public static class LocationUtils
     {
+        private static int maxRayTraceDistance = 100;
+
         public static Vec3d GetLocationOfPlayer(ICoreClientAPI api)
         {
             if (api == null)
@@ -53,6 +59,62 @@ namespace rpvoicechat.Utils
             );
 
             return rotatedVector.ToVec3f();
+        }
+
+        /// <summary>
+        /// Calculates obstruction level between two given players
+        /// </summary>
+        /// <returns>Combined volume of obstructing blocks</returns>
+        public static float GetWallThickness(ICoreClientAPI capi, IPlayer source, IPlayer target)
+        {
+            var origin = GetLocationOfPlayer(source);
+            var destination = GetLocationOfPlayer(target);
+
+            var obstructingBlocks = RayTraceThrough(capi, origin, destination).Item1;
+            float thickness = 0;
+            foreach (BlockEntry blockEntry in obstructingBlocks)
+            {
+                var block = blockEntry.Item2;
+                var collisionBoxes = block?.CollisionBoxes ?? new Cuboidf[0];
+                foreach (Cuboidf box in collisionBoxes)
+                    thickness += box.Length * box.Height * box.Width;
+            }
+
+            return thickness;
+        }
+
+        /// <summary>
+        /// Casts a ray between two given positions
+        /// </summary>
+        /// <returns>Two lists containing blocks and entities intersected by the ray</returns>
+        public static RayTraceResults RayTraceThrough(ICoreClientAPI capi, Vec3d from, Vec3d to)
+        {
+            var visitedBlocks = new List<BlockEntry>();
+            var visitedEntities = new List<Entity>();
+            EntityFilter entityFilter = entity => {
+                return !(visitedEntities.Contains(entity) || entity.Class == "EntityPlayer");
+            };
+            BlockFilter blockFilter = (pos, block) => {
+                var blockEntry = new BlockEntry(pos.Copy(), block);
+                return !visitedBlocks.Contains(blockEntry);
+            };
+
+            for (var i = 0; i < maxRayTraceDistance; i++)
+            {
+                BlockSelection blockSelection = new BlockSelection();
+                EntitySelection entitySelection = new EntitySelection();
+                capi.World.RayTraceForSelection(from, to, ref blockSelection, ref entitySelection, blockFilter, entityFilter);
+
+                if (blockSelection == null && entitySelection == null) break;
+                if (entitySelection?.Entity != null) visitedEntities.Add(entitySelection.Entity);
+                if (blockSelection?.Block != null && blockSelection?.Position is BlockPos)
+                {
+                    var blockEntry = new BlockEntry(blockSelection.Position.Copy(), blockSelection.Block);
+                    visitedBlocks.Add(blockEntry);
+                }
+            }
+
+            return new RayTraceResults(visitedBlocks, visitedEntities);
         }
 
         private static Vec3d GetSpeakerLocation(EntityPos pos)

--- a/src/Utils/PlayerAudioSource.cs
+++ b/src/Utils/PlayerAudioSource.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 public class PlayerAudioSource : IDisposable
 {
-    public const int BufferCount = 4;
+    public const int BufferCount = 8;
 
     private int source;
 

--- a/src/Utils/PlayerAudioSource.cs
+++ b/src/Utils/PlayerAudioSource.cs
@@ -90,7 +90,7 @@ public class PlayerAudioSource : IDisposable
     {
         EntityPos speakerPos = player.Entity?.SidedPos;
         EntityPos listenerPos = capi.World.Player.Entity?.SidedPos;
-        if (speakerPos == null || listenerPos == null)
+        if (speakerPos == null || listenerPos == null || !outputManager.isReady)
             return;
 
         // If the player is on the other side of something to the listener, then the player's voice should be muffled

--- a/src/Utils/PlayerAudioSource.cs
+++ b/src/Utils/PlayerAudioSource.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 public class PlayerAudioSource : IDisposable
 {
-    public const int BufferCount = 8;
+    public const int BufferCount = 4;
 
     private int source;
 

--- a/src/Utils/PlayerAudioSource.cs
+++ b/src/Utils/PlayerAudioSource.cs
@@ -99,7 +99,7 @@ public class PlayerAudioSource : IDisposable
         {
             lowpassFilter = lowpassFilter ?? new FilterLowpass(EffectsExtension, source);
             lowpassFilter.Start();
-            lowpassFilter.SetHFGain(Math.Max(1.0f - (wallThickness / 2), 0.1f));
+            lowpassFilter.SetHFGain(Math.Max(1.0f - (wallThickness / 5), 0.1f));
         } else
         {
             lowpassFilter?.Stop();


### PR DESCRIPTION
Improves muffling effect to take thickness of obstructing blocks into account
Adds utility for proper ray tracing: 
- Method provided by game API only returns first intersected block/entity
- Method provided by game API has few bugs/nondeterministic behaviors 
- Custom implementation returns all intersected blocks and entities 
- Custom implementation is more deterministic and stable

Changes the way `UpdatePlayer` is called: 
- Old implementation: 
  - Was called 10 times per second for every player in 100 block radius 
- New implementation:
  - Is called upon receiving audio packet from player 
  - From my tests it results in at most 8 calls per second when using PTT and about half when using input threshold
  - Makes audio more smooth since source parameters no longer change mid playback 
  - Improves client performance, especially at scale
  
Minor code style changes
Adjusts distance-based volume decay speed to make whispering and shouting more authentic
Adjusts wall insulation strength to reach max muffling effect at 5-block thick wall instead of 10
Fixes an incorrectly resolved conflict from ddd44220ae752e8a17f0e9603da457663adda4a8 in #18
Sets default namespace name to `rpvoicechat`