### PR TITLE
Audio capture fixes

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
   "authors": [ "Ridderrasmus", "Purplep_", "blakdragan7" ],
   "contributors": [ "Dmitry221060" ],
   "description": "A mod that adds in game voice proximity chat!",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/src/Audio/MicrophoneManager.cs
+++ b/src/Audio/MicrophoneManager.cs
@@ -182,7 +182,7 @@ namespace RPVoiceChat
                 Amplitude = data.Amplitude;
                 recentAmplitudes.Add(Amplitude);
 
-                if (recentAmplitudes.Count > 20)
+                if (recentAmplitudes.Count > 3)
                 {
                     recentAmplitudes.RemoveAt(0);
 

--- a/src/Audio/MicrophoneManager.cs
+++ b/src/Audio/MicrophoneManager.cs
@@ -64,9 +64,6 @@ namespace RPVoiceChat
             SetThreshold(config.InputThreshold);
 
             CreateNewCapture(config.CurrentInputDevice);
-            
-                capture = new AudioCapture(config.CurrentInputDevice, Frequency, InputFormat, BufferSize);
-            
         }
 
         public void Launch()

--- a/src/Audio/MicrophoneManager.cs
+++ b/src/Audio/MicrophoneManager.cs
@@ -173,7 +173,11 @@ namespace RPVoiceChat
         {
             while (audioProcessingThread.IsAlive)
             {
-                if (!audioDataQueue.TryDequeue(out var data)) Thread.Sleep(30);
+                if (!audioDataQueue.TryDequeue(out var data))
+                {
+                    Thread.Sleep(30);
+                    continue;
+                }
 
                 Amplitude = data.Amplitude;
                 recentAmplitudes.Add(Amplitude);

--- a/src/Client/PlayerNetworkClient.cs
+++ b/src/Client/PlayerNetworkClient.cs
@@ -52,6 +52,7 @@ namespace RPVoiceChat.Client
                 clientConnection.SupportedTransports = new string[] { clientTransportID };
                 handshakeChannel.SendPacket(clientConnection);
                 isConnected = true;
+                Logger.client.Notification($"Successfully connected with the {clientTransportID} client");
                 return;
             }
             catch (Exception e)

--- a/src/Gui/ConfigDialog.cs
+++ b/src/Gui/ConfigDialog.cs
@@ -149,7 +149,9 @@ namespace RPVoiceChat
         private void TickUpdate(float obj)
         {
             AudioMeter?.SetThreshold(_audioInputManager.GetInputThreshold());
-            AudioMeter?.UpdateVisuals(Math.Max(_audioInputManager.Amplitude, _audioInputManager.AmplitudeAverage));
+            var amplitude = Math.Max(_audioInputManager.Amplitude, _audioInputManager.AmplitudeAverage);
+            if (ModConfig.Config.IsMuted) amplitude = 0;
+            AudioMeter?.UpdateVisuals(amplitude);
         }
 
         protected abstract void RefreshValues();

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -35,15 +35,20 @@ namespace RPVoiceChat.Server
             serverByTransport = new Dictionary<string, INetworkServer>();
             try
             {
+                Logger.server.Notification($"Launching {networkServer.GetTransportID()} server");
                 var extendedServer = networkServer as IExtendedNetworkServer;
                 extendedServer?.Launch();
                 api.Event.PlayerNowPlaying += PlayerJoined;
                 api.Event.PlayerDisconnect += PlayerLeft;
                 networkServer.OnReceivedPacket += SendAudioToAllClientsInRange;
                 serverByTransport.Add(networkServer.GetTransportID(), networkServer);
+                Logger.server.Notification($"{networkServer.GetTransportID()} server started");
+
                 if (reserveServer == null) return;
+                Logger.server.Notification($"Launching {reserveServer.GetTransportID()} server");
                 reserveServer.OnReceivedPacket += SendAudioToAllClientsInRange;
                 serverByTransport.Add(reserveServer.GetTransportID(), reserveServer);
+                Logger.server.Notification($"{reserveServer.GetTransportID()} server started");
                 return;
             }
             catch (Exception e)

--- a/src/Utils/Logger.cs
+++ b/src/Utils/Logger.cs
@@ -25,6 +25,7 @@ namespace RPVoiceChat.Utils
         public void Error(string message, params object[] args)
         {
             api.Logger.Error($"[RPVoiceChat] {message}", args);
+            api.Logger.VerboseDebug($"[Error] [RPVoiceChat] {message}", args);
         }
 
         public void Debug(string message)
@@ -55,6 +56,7 @@ namespace RPVoiceChat.Utils
         public void Warning(string message, params object[] args)
         {
             api.Logger.Warning($"[RPVoiceChat] {message}", args);
+            api.Logger.VerboseDebug($"[Warning] [RPVoiceChat] {message}", args);
         }
 
         public void Notification(string message)
@@ -65,6 +67,7 @@ namespace RPVoiceChat.Utils
         public void Notification(string message, params object[] args)
         {
             api.Logger.Notification($"[RPVoiceChat] {message}", args);
+            api.Logger.VerboseDebug($"[Notification] [RPVoiceChat] {message}", args);
         }
     }
 }


### PR DESCRIPTION
Changes how audio is captured on windows:
- Old behavior:
  - Can only capture one channel
  - Always captures first channel
- New behavior:
  - Can capture up to 4 channels
  - Automatically detects what channels are used
  - Merges all captured channels into a single mono channel
 
Fixes a bug in dequeuing audio data that was causing multiple abnormal amplitude behaviors
Fixes #24 
Adds extra logging
Duplicates custom logs from `-main.txt` into `-debug.txt`
Bumps version