### PR TITLE
Audio quality changes

### DIFF
--- a/src/Audio/AudioOutputManager.cs
+++ b/src/Audio/AudioOutputManager.cs
@@ -114,9 +114,7 @@ namespace RPVoiceChat.Audio
         {
             localPlayerAudioSource = new PlayerAudioSource(capi.World.Player, this, capi)
             {
-                IsMuffled = false,
-                IsReverberated = false,
-                IsLocational = false
+                IsLocational = false,
             };
 
             if (!isLoopbackEnabled) return;
@@ -129,9 +127,7 @@ namespace RPVoiceChat.Audio
 
             var playerSource = new PlayerAudioSource(player, this, capi)
             {
-                IsMuffled = false,
-                IsReverberated = false,
-                IsLocational = true
+                IsLocational = true,
             };
 
             if (playerSources.TryAdd(player.PlayerUID, playerSource) == false)

--- a/src/Audio/MicrophoneManager.cs
+++ b/src/Audio/MicrophoneManager.cs
@@ -340,12 +340,6 @@ namespace RPVoiceChat.Audio
             return voiceLevel;
         }
 
-        public void SetVoiceLevel(VoiceLevel level)
-        {
-            voiceLevel = level;
-            VoiceLevelUpdated?.Invoke(voiceLevel);
-        }
-
         public VoiceLevel GetVoiceLevel()
         {
             return voiceLevel;

--- a/src/Audio/PlayerAudioSource.cs
+++ b/src/Audio/PlayerAudioSource.cs
@@ -29,8 +29,6 @@ namespace RPVoiceChat.Audio
 
         private Vec3f lastSpeakerCoords;
         private DateTime lastSpeakerUpdate;
-        public bool IsMuffled { get; set; } = false;
-        public bool IsReverberated { get; set; } = false;
 
         public bool IsLocational { get; set; } = true;
         public VoiceLevel voiceLevel { get; private set; } = VoiceLevel.Talking;
@@ -98,7 +96,6 @@ namespace RPVoiceChat.Audio
 
             // If the player is on the other side of something to the listener, then the player's voice should be muffled
             float wallThickness = LocationUtils.GetWallThickness(capi, player, capi.World.Player);
-
             if (capi.World.Player.Entity.Swimming)
                 wallThickness += 1.0f;
 
@@ -111,7 +108,8 @@ namespace RPVoiceChat.Audio
             }
 
             // If the player is in a reverberated area, then the player's voice should be reverberated
-            if (IsReverberated)
+            bool isReverberated = false;
+            if (isReverberated)
             {
 
             }

--- a/src/Gui/ConfigDialog.cs
+++ b/src/Gui/ConfigDialog.cs
@@ -245,7 +245,6 @@ namespace RPVoiceChat
         {
             _config.IsHUDShown = enabled;
             ModConfig.Save(capi);
-            _audioInputManager.SetVoiceLevel(_audioInputManager.GetVoiceLevel());
         }
 
         protected void OnToggleLoopback(bool enabled)

--- a/src/Gui/VoiceLevelIcon.cs
+++ b/src/Gui/VoiceLevelIcon.cs
@@ -25,14 +25,13 @@ namespace RPVoiceChat
         };
 
         VoiceLevel currentVoiceLevel;
-        
-        private RPVoiceChatConfig _config;
 
-        public VoiceLevelIcon(ICoreClientAPI capi, MicrophoneManager microphoneManager, RPVoiceChatConfig config) : base(capi)
+        public VoiceLevelIcon(ICoreClientAPI capi, MicrophoneManager microphoneManager) : base(capi)
         {
-            this._config = config;
-            microphoneManager.VoiceLevelUpdated += OnVoiceLevelUpdated;
             currentVoiceLevel = microphoneManager.GetVoiceLevel();
+
+            microphoneManager.VoiceLevelUpdated += OnVoiceLevelUpdated;
+            ModConfig.ConfigUpdated += bindToMainThread(OnConfigUpdate);
         }
 
         public override void OnOwnPlayerDataReceived()
@@ -40,27 +39,38 @@ namespace RPVoiceChat
             SetupIcon();
         }
 
+        private Action bindToMainThread(Action function)
+        {
+            return () => { capi.Event.EnqueueMainThreadTask(function, "rpvoicechat:VoiceLevelIcon"); };
+        }
+
         private void OnVoiceLevelUpdated(VoiceLevel voiceLevel)
         {
             currentVoiceLevel = voiceLevel;
-            capi.Event.EnqueueMainThreadTask(SetupIcon, "rpvoicechat:VoiceLevelIcon");
+            bindToMainThread(SetupIcon)();
+        }
+
+        private void OnConfigUpdate()
+        {
+            SetupIcon();
+        }
+
+        private void UpdateDisplay()
+        {
+            bool shouldDisplay = ModConfig.Config.IsHUDShown;
+            bool successful = shouldDisplay ? TryOpen() : TryClose();
+
+            if (!successful) bindToMainThread(UpdateDisplay)();
         }
 
         public void SetupIcon()
         {
-            if(!_config.IsHUDShown)
-            {
-                TryClose();
-                return;
-            }
-
-
             string voiceLevel = textureNameByVoiceLevel[currentVoiceLevel];
             SingleComposer = capi.Gui.CreateCompo("rpvcvoicelevelicon", dialogBounds)
                 .AddImage(ElementBounds.Fixed(0, 0, size, size), new AssetLocation("rpvoicechat", $"textures/gui/{voiceLevel}.png"))
                 .Compose();
 
-            TryOpen();
+            UpdateDisplay();
         }
     }
 }

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -46,7 +46,7 @@ namespace RPVoiceChat
             // Initialize gui
             configGui = new MainConfig(capi, micManager, audioOutputManager);
             capi.Gui.RegisterDialog(new SpeechIndicator(capi, micManager));
-            capi.Gui.RegisterDialog(new VoiceLevelIcon(capi, micManager, config));
+            capi.Gui.RegisterDialog(new VoiceLevelIcon(capi, micManager));
 
             // Set up keybinds
             capi.Input.RegisterHotKey("voicechatMenu", "RPVoice: Config menu", GlKeys.P, HotkeyType.GUIOrOtherControls);

--- a/src/Utils/LocationUtils.cs
+++ b/src/Utils/LocationUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
@@ -13,6 +14,12 @@ namespace RPVoiceChat.Utils
     public static class LocationUtils
     {
         private static int maxRayTraceDistance = 100;
+        private static string[] transparentBlocks = new string[]
+        {
+            "BlockGroundStorage",
+            "BlockPie",
+            "BlockSupportBeam"
+        };
 
         public static Vec3d GetLocationOfPlayer(ICoreClientAPI api)
         {
@@ -85,6 +92,7 @@ namespace RPVoiceChat.Utils
             foreach (BlockEntry blockEntry in obstructingBlocks)
             {
                 var block = blockEntry.Item2;
+                if (transparentBlocks.Contains(block.Class)) continue;
                 var collisionBoxes = block?.CollisionBoxes ?? new Cuboidf[0];
                 foreach (Cuboidf box in collisionBoxes)
                     thickness += box.Length * box.Height * box.Width;

--- a/src/Utils/LocationUtils.cs
+++ b/src/Utils/LocationUtils.cs
@@ -91,9 +91,20 @@ namespace RPVoiceChat.Utils
             float thickness = 0;
             foreach (BlockEntry blockEntry in obstructingBlocks)
             {
+                var blockPos = blockEntry.Item1;
                 var block = blockEntry.Item2;
-                if (transparentBlocks.Contains(block.Class)) continue;
-                var collisionBoxes = block?.CollisionBoxes ?? new Cuboidf[0];
+                if (transparentBlocks.Contains(block?.Class)) continue;
+
+                var collisionBoxes = new Cuboidf[0];
+                try
+                {
+                    collisionBoxes = block?.GetCollisionBoxes(capi.World.BlockAccessor, blockPos) ?? collisionBoxes;
+                }
+                catch(Exception e)
+                {
+                    Logger.client.Warning($"Couldn't retrieve collision boxes for {block.Class} at {blockPos}:\n{e}");
+                }
+
                 foreach (Cuboidf box in collisionBoxes)
                     thickness += box.Length * box.Height * box.Width;
             }


### PR DESCRIPTION
#### Muffling intensity
Excludes pies, beams and ground storage objects(piles of stuff, bowls, crocks, tools, etc) from obstruction level calculation, so they don't cause muffling
Fixes a bug in obstruction level calculation causing all solid hitboxes to count as a full block

#### Distance attenuation
Moves distance attenuation into OpenAL
Adjusts whispering attenuation to begin later and be slower, making whispering more comfortable to use
Fixes two points on the attenuation graph:
1. Distance at which source gain begins to fade (Reference distance)
2. Gain value at the edge of hearing range (assuming same Reference distance)
This has no effect on default settings, but makes custom voice level distances more predictable and stable (setting whispering distance to 10 won't make it inaudible, setting shouting to 15 won't make it cut-off at 60% volume, etc)  

#### Other
Makes toggle hud implementation coherent among hud icons
Cleanups some unused code