### PR TITLE
Audio volume sliders

### DIFF
--- a/src/Audio/AudioOutputManager.cs
+++ b/src/Audio/AudioOutputManager.cs
@@ -41,12 +41,14 @@ namespace RPVoiceChat.Audio
         public EffectsExtension EffectsExtension;
         private ConcurrentDictionary<string, PlayerAudioSource> playerSources = new ConcurrentDictionary<string, PlayerAudioSource>();
         private PlayerAudioSource localPlayerAudioSource;
+        private PlayerListener listener;
 
         public AudioOutputManager(ICoreClientAPI api)
         {
             _config = ModConfig.Config;
             IsLoopbackEnabled = _config.IsLoopbackEnabled;
             capi = api;
+            listener = new PlayerListener(api);
 
             EffectsExtension = new EffectsExtension();
         }

--- a/src/Audio/CircularAudioBufer.cs
+++ b/src/Audio/CircularAudioBufer.cs
@@ -39,7 +39,9 @@ namespace RPVoiceChat.Audio
             OALW.ExecuteInContext(() =>
             {
                 AL.BufferData(currentBuffer, format, audio, length, frequency);
+                OALW.CheckError("Error buffer data");
                 AL.SourceQueueBuffer(source, currentBuffer);
+                OALW.CheckError("Error SourceQueueBuffer");
             });
             queuedBuffers.Add(currentBuffer);
         }

--- a/src/Audio/CircularAudioBufer.cs
+++ b/src/Audio/CircularAudioBufer.cs
@@ -18,8 +18,7 @@ namespace RPVoiceChat.Audio
         public CircularAudioBuffer(int source, int bufferCount)
         {
             this.source = source;
-            buffers = AL.GenBuffers(bufferCount);
-            Util.CheckError("Error gen buffers");
+            buffers = OALW.GenBuffers(bufferCount);
             availableBuffers.AddRange(buffers);
 
             dequeueAudioThread = new Thread(DequeueAudio);
@@ -37,10 +36,8 @@ namespace RPVoiceChat.Audio
 
             var currentBuffer = availableBuffers.PopOne();
 
-            AL.BufferData(currentBuffer, format, audio, length, frequency);
-            Util.CheckError("Error buffer data");
-            AL.SourceQueueBuffer(source, currentBuffer);
-            Util.CheckError("Error SourceQueueBuffer");
+            OALW.BufferData(currentBuffer, format, audio, length, frequency);
+            OALW.SourceQueueBuffer(source, currentBuffer);
             queuedBuffers.Add(currentBuffer);
         }
 
@@ -57,12 +54,11 @@ namespace RPVoiceChat.Audio
         {
             if (queuedBuffers.Count == 0) return;
 
-            AL.GetSource(source, ALGetSourcei.BuffersProcessed, out var buffersProcessed);
+            OALW.GetSource(source, ALGetSourcei.BuffersProcessed, out var buffersProcessed);
             if (buffersProcessed == 0) return;
 
             var processedBuffers = queuedBuffers.GetRange(0, buffersProcessed);
-            AL.SourceUnqueueBuffers(source, buffersProcessed, processedBuffers.ToArray());
-            Util.CheckError("Error SourceUnqueueBuffer", ALError.InvalidValue);
+            OALW.SourceUnqueueBuffers(source, buffersProcessed, processedBuffers.ToArray());
             queuedBuffers.RemoveRange(0, buffersProcessed);
             availableBuffers.AddRange(processedBuffers);
         }
@@ -70,7 +66,7 @@ namespace RPVoiceChat.Audio
         public void Dispose()
         {
             dequeueAudioThread?.Abort();
-            AL.DeleteBuffers(buffers);
+            OALW.DeleteBuffers(buffers);
         }
     }
 }

--- a/src/Audio/CircularAudioBufer.cs
+++ b/src/Audio/CircularAudioBufer.cs
@@ -36,8 +36,11 @@ namespace RPVoiceChat.Audio
 
             var currentBuffer = availableBuffers.PopOne();
 
-            OALW.BufferData(currentBuffer, format, audio, length, frequency);
-            OALW.SourceQueueBuffer(source, currentBuffer);
+            OALW.ExecuteInContext(() =>
+            {
+                AL.BufferData(currentBuffer, format, audio, length, frequency);
+                AL.SourceQueueBuffer(source, currentBuffer);
+            });
             queuedBuffers.Add(currentBuffer);
         }
 

--- a/src/Audio/MicrophoneManager.cs
+++ b/src/Audio/MicrophoneManager.cs
@@ -16,7 +16,7 @@ namespace RPVoiceChat.Audio
         public ALFormat InputFormat { get; private set; }
         private ALFormat OutputFormat = ALFormat.Mono16;
         private int BufferSize = (int)(Frequency * 0.5);
-        private float gain = 1;
+        private float gain;
         private int channelCount;
         private const byte SampleToByte = 2;
         private double MaxInputThreshold;

--- a/src/Audio/MicrophoneManager.cs
+++ b/src/Audio/MicrophoneManager.cs
@@ -16,6 +16,7 @@ namespace RPVoiceChat.Audio
         public ALFormat InputFormat { get; private set; }
         private ALFormat OutputFormat = ALFormat.Mono16;
         private int BufferSize = (int)(Frequency * 0.5);
+        private float gain = 1;
         private int channelCount;
         private const byte SampleToByte = 2;
         private double MaxInputThreshold;
@@ -53,6 +54,7 @@ namespace RPVoiceChat.Audio
             config = ModConfig.Config;
             MaxInputThreshold = config.MaxInputThreshold;
             SetThreshold(config.InputThreshold);
+            SetGain(config.InputGain);
 
             capture = CreateNewCapture(config.CurrentInputDevice);
         }
@@ -88,6 +90,11 @@ namespace RPVoiceChat.Audio
             inputThreshold = (threshold / 100.0) * MaxInputThreshold;
         }
 
+        public void SetGain(int newGain)
+        {
+            gain = newGain / 100f;
+        }
+
         public void UpdateCaptureAudioSamples(float deltaTime)
         {
             bool isMuted = config.IsMuted;
@@ -112,7 +119,7 @@ namespace RPVoiceChat.Audio
         }
 
         /// <summary>
-        /// Converts audio to Mono16 and calculates amplitude
+        /// Converts audio to Mono16, applies gain and calculates amplitude
         /// </summary>
         private AudioData PreprocessRawAudio(byte[] rawSamples)
         {
@@ -136,6 +143,7 @@ namespace RPVoiceChat.Audio
                     monoSample += sample;
                 }
                 monoSample = monoSample / usedChannels.Length;
+                monoSample = monoSample * gain;
 
                 var monoBytes = BitConverter.GetBytes((short)monoSample);
                 var monoSampleIndex = rawSampleIndex / rawSampleSize * monoSampleSize;

--- a/src/Audio/OpenALWrapper.cs
+++ b/src/Audio/OpenALWrapper.cs
@@ -1,0 +1,219 @@
+﻿using OpenTK;
+using OpenTK.Audio.OpenAL;
+using RPVoiceChat.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RPVoiceChat.Audio
+{
+    public static class OALW
+    {
+        private static ContextHandle context;
+
+        public static void InitContext()
+        {
+            if (context != null) Alc.DestroyContext(context);
+
+            var device = Alc.OpenDevice(null);
+            var attrs = new int[0];
+            context = Alc.CreateContext(device, attrs);
+        }
+
+        public static void Source(int source, ALSourceb property, bool value)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.Source(source, property, value);
+            CheckError($"Error setting source {property}");
+
+            ResetContext(ctx);
+        }
+
+        public static void Source(int source, ALSourcef property, float value)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.Source(source, property, value);
+            CheckError($"Error setting source {property}");
+
+            ResetContext(ctx);
+        }
+
+        public static void Source(int source, ALSource3f property, float value1, float value2, float value3)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.Source(source, property, value1, value2, value3);
+            CheckError($"Error setting source {property}");
+
+            ResetContext(ctx);
+        }
+
+        public static void Listener(ALListenerf property, float value)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.Listener(property, value);
+            CheckError($"Error setting listener's {property}");
+
+            ResetContext(ctx);
+        }
+
+        public static int GenSource()
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            var source = AL.GenSource();
+            CheckError("Error gen source");
+
+            ResetContext(ctx);
+            return source;
+        }
+
+        public static void GetSource(int source, ALGetSourcei property, out int result)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.GetSource(source, property, out result);
+
+            ResetContext(ctx);
+        }
+
+        public static ALSourceState GetSourceState(int source)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            var state = AL.GetSourceState(source);
+            CheckError("Error getting source state");
+
+            ResetContext(ctx);
+            return state;
+        }
+
+        public static void SourcePlay(int source)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.SourcePlay(source);
+            CheckError("Error playing source");
+
+            ResetContext(ctx);
+        }
+
+        public static void SourceStop(int source)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.SourceStop(source);
+            CheckError("Error stop playing source");
+
+            ResetContext(ctx);
+        }
+
+        public static void DeleteSource(int source)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.DeleteSource(source);
+            CheckError("Error deleting source");
+
+            ResetContext(ctx);
+        }
+
+        public static int[] GenBuffers(int bufferCount)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            var buffers = AL.GenBuffers(bufferCount);
+            CheckError("Error gen buffers");
+
+            ResetContext(ctx);
+            return buffers;
+        }
+
+        public static void BufferData(int buffer, ALFormat format, byte[] audio, int length, int frequency)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.BufferData(buffer, format, audio, length, frequency);
+            CheckError("Error buffer data");
+
+            ResetContext(ctx);
+        }
+
+        public static void SourceQueueBuffer(int source, int buffer)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.SourceQueueBuffer(source, buffer);
+            CheckError("Error SourceQueueBuffer");
+
+            ResetContext(ctx);
+        }
+
+        public static void SourceUnqueueBuffers(int source, int bufferCount, int[] buffers)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.SourceUnqueueBuffers(source, bufferCount, buffers);
+            CheckError("Error SourceUnqueueBuffer", ALError.InvalidValue);
+
+            ResetContext(ctx);
+        }
+
+        public static void DeleteBuffers(int[] buffers)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            AL.DeleteBuffers(buffers);
+
+            ResetContext(ctx);
+        }
+
+        private static ContextHandle? SetCurrentContext()
+        {
+            var oldContext = Alc.GetCurrentContext();
+            if (oldContext == context) return null;
+
+            Alc.MakeContextCurrent(context);
+
+            return oldContext;
+        }
+
+        private static void ResetContext(ContextHandle? ctx)
+        {
+            if (ctx == null) return;
+
+            Alc.MakeContextCurrent((ContextHandle)ctx);
+        }
+
+        private static void CheckError(string Value, ALError ignoredErrors = ALError.NoError)
+        {
+            var error = AL.GetError();
+            if (error == ALError.NoError) return;
+
+            if (ignoredErrors == error)
+                return;
+
+            Logger.client.Error("{0} {1}", Value, AL.GetErrorString(error));
+        }
+    }
+}

--- a/src/Audio/OpenALWrapper.cs
+++ b/src/Audio/OpenALWrapper.cs
@@ -22,170 +22,130 @@ namespace RPVoiceChat.Audio
             context = Alc.CreateContext(device, attrs);
         }
 
-        public static void Source(int source, ALSourceb property, bool value)
+        public static void ExecuteInContext(Action action)
         {
             if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
             var ctx = SetCurrentContext();
 
-            AL.Source(source, property, value);
-            CheckError($"Error setting source {property}");
+            action();
 
             ResetContext(ctx);
+        }
+
+        public static T ExecuteInContext<T>(Func<T> function)
+        {
+            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
+            var ctx = SetCurrentContext();
+
+            var result = function();
+
+            ResetContext(ctx);
+            return result;
+        }
+
+        public static void Source(int source, ALSourceb property, bool value)
+        {
+            ExecuteInContext(() =>
+            {
+                AL.Source(source, property, value);
+                CheckError($"Error setting source {property}");
+            });
         }
 
         public static void Source(int source, ALSourcef property, float value)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.Source(source, property, value);
-            CheckError($"Error setting source {property}");
-
-            ResetContext(ctx);
-        }
-
-        public static void Source(int source, ALSource3f property, float value1, float value2, float value3)
-        {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.Source(source, property, value1, value2, value3);
-            CheckError($"Error setting source {property}");
-
-            ResetContext(ctx);
+            ExecuteInContext(() =>
+            {
+                AL.Source(source, property, value);
+                CheckError($"Error setting source {property}");
+            });
         }
 
         public static void Listener(ALListenerf property, float value)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.Listener(property, value);
-            CheckError($"Error setting listener's {property}");
-
-            ResetContext(ctx);
+            ExecuteInContext(() =>
+            {
+                AL.Listener(property, value);
+                CheckError($"Error setting listener's {property}");
+            });
         }
 
         public static int GenSource()
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
+            return ExecuteInContext(() =>
+            {
+                var source = AL.GenSource();
+                CheckError("Error generating source");
 
-            var source = AL.GenSource();
-            CheckError("Error gen source");
-
-            ResetContext(ctx);
-            return source;
-        }
-
-        public static void GetSource(int source, ALGetSourcei property, out int result)
-        {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.GetSource(source, property, out result);
-
-            ResetContext(ctx);
+                return source;
+            });
         }
 
         public static ALSourceState GetSourceState(int source)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
+            return ExecuteInContext(() =>
+            {
+                var state = AL.GetSourceState(source);
+                CheckError("Error getting source state");
 
-            var state = AL.GetSourceState(source);
-            CheckError("Error getting source state");
-
-            ResetContext(ctx);
-            return state;
+                return state;
+            });
         }
 
         public static void SourcePlay(int source)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.SourcePlay(source);
-            CheckError("Error playing source");
-
-            ResetContext(ctx);
+            ExecuteInContext(() =>
+            {
+                AL.SourcePlay(source);
+                CheckError("Error playing source");
+            });
         }
 
         public static void SourceStop(int source)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.SourceStop(source);
-            CheckError("Error stop playing source");
-
-            ResetContext(ctx);
+            ExecuteInContext(() =>
+            {
+                AL.SourceStop(source);
+                CheckError("Error stop playing source");
+            });
         }
 
         public static void DeleteSource(int source)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.DeleteSource(source);
-            CheckError("Error deleting source");
-
-            ResetContext(ctx);
+            ExecuteInContext(() =>
+            {
+                AL.DeleteSource(source);
+                CheckError("Error deleting source");
+            });
         }
 
         public static int[] GenBuffers(int bufferCount)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
+            return ExecuteInContext(() =>
+            {
+                var buffers = AL.GenBuffers(bufferCount);
+                CheckError("Error gen buffers");
 
-            var buffers = AL.GenBuffers(bufferCount);
-            CheckError("Error gen buffers");
-
-            ResetContext(ctx);
-            return buffers;
-        }
-
-        public static void BufferData(int buffer, ALFormat format, byte[] audio, int length, int frequency)
-        {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.BufferData(buffer, format, audio, length, frequency);
-            CheckError("Error buffer data");
-
-            ResetContext(ctx);
-        }
-
-        public static void SourceQueueBuffer(int source, int buffer)
-        {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.SourceQueueBuffer(source, buffer);
-            CheckError("Error SourceQueueBuffer");
-
-            ResetContext(ctx);
-        }
-
-        public static void SourceUnqueueBuffers(int source, int bufferCount, int[] buffers)
-        {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
-
-            AL.SourceUnqueueBuffers(source, bufferCount, buffers);
-            CheckError("Error SourceUnqueueBuffer", ALError.InvalidValue);
-
-            ResetContext(ctx);
+                return buffers;
+            });
         }
 
         public static void DeleteBuffers(int[] buffers)
         {
-            if (context == null) throw new Exception("OpenAL audio context has not been initialized.");
-            var ctx = SetCurrentContext();
+            ExecuteInContext(() =>
+            {
+                AL.DeleteBuffers(buffers);
+                CheckError("Error deleting buffers");
+            });
+        }
 
-            AL.DeleteBuffers(buffers);
+        public static void CheckError(string Value, ALError ignoredErrors = ALError.NoError)
+        {
+            var error = AL.GetError();
+            if (error == ALError.NoError) return;
+            if (ignoredErrors == error) return;
 
-            ResetContext(ctx);
+            Logger.client.Error("{0} {1}", Value, AL.GetErrorString(error));
         }
 
         private static ContextHandle? SetCurrentContext()
@@ -203,17 +163,6 @@ namespace RPVoiceChat.Audio
             if (ctx == null) return;
 
             Alc.MakeContextCurrent((ContextHandle)ctx);
-        }
-
-        private static void CheckError(string Value, ALError ignoredErrors = ALError.NoError)
-        {
-            var error = AL.GetError();
-            if (error == ALError.NoError) return;
-
-            if (ignoredErrors == error)
-                return;
-
-            Logger.client.Error("{0} {1}", Value, AL.GetErrorString(error));
         }
     }
 }

--- a/src/Audio/PlayerListener.cs
+++ b/src/Audio/PlayerListener.cs
@@ -9,7 +9,7 @@ namespace RPVoiceChat.Audio
     public class PlayerListener
     {
         private ICoreClientAPI capi;
-        private float gain = 1;
+        private float gain;
 
         public PlayerListener(ICoreClientAPI api)
         {

--- a/src/Audio/PlayerListener.cs
+++ b/src/Audio/PlayerListener.cs
@@ -1,45 +1,36 @@
-﻿using Vintagestory.API.Common.Entities;
-using Vintagestory.API.MathTools;
+﻿using OpenTK;
+using OpenTK.Audio;
+using OpenTK.Audio.OpenAL;
+using RPVoiceChat.Utils;
+using Vintagestory.API.Client;
 
 namespace RPVoiceChat.Audio
 {
     public class PlayerListener
     {
-        private Vec3d listenerPos;
-        private float facing;
+        private ICoreClientAPI capi;
+        private float gain = 1;
 
-        public PlayerListener(Vec3d listenerPos, float facing)
+        public PlayerListener(ICoreClientAPI api)
         {
-            this.listenerPos = listenerPos;
-            this.facing = facing;
+            capi = api;
+            SetGain(ModConfig.Config.OutputGain);
+
+            ModConfig.ConfigUpdated += OnConfigUpdate;
         }
 
-        public PlayerListener(EntityPos pos)
+        public void SetGain(float newGain)
         {
-            this.listenerPos.Set(pos.X, pos.Y, pos.Z);
-            this.facing = pos.Yaw + pos.HeadYaw;
+            newGain /= 100f;
+            if (newGain == gain) return;
+
+            gain = newGain;
+            OALW.Listener(ALListenerf.Gain, gain);
         }
 
-        public void UpdateListener(Vec3d listenerPos, float facing)
+        private void OnConfigUpdate()
         {
-            this.listenerPos.Set(listenerPos);
-            this.facing = facing;
-        }
-
-        public void UpdateListener(EntityPos pos)
-        {
-            this.listenerPos.Set(pos.X, pos.Y, pos.Z);
-            this.facing = pos.Yaw + pos.HeadYaw;
-        }
-
-        public Vec3d GetListenerPos()
-        {
-            return listenerPos;
-        }
-
-        public float GetFacing()
-        {
-            return facing;
+            SetGain(ModConfig.Config.OutputGain);
         }
     }
 }

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -21,6 +21,8 @@
         public bool IsLoopbackEnabled = false;
         public bool IsHUDShown = true;
         public bool IsMuted = false;
+        public int OutputGain = 200;
+        public int InputGain = 100;
         public int InputThreshold = 20;
         public string CurrentInputDevice = OpenTK.Audio.AudioCapture.DefaultDevice;
         // These are client settings but they are not
@@ -44,6 +46,8 @@
             PushToTalkEnabled = previousConfig.PushToTalkEnabled;
             IsHUDShown = previousConfig.IsHUDShown;
             IsMuted = previousConfig.IsMuted;
+            OutputGain = previousConfig.OutputGain;
+            InputGain = previousConfig.InputGain;
             InputThreshold = previousConfig.InputThreshold;
             CurrentInputDevice = previousConfig.CurrentInputDevice;
             IsLoopbackEnabled = previousConfig.IsLoopbackEnabled;

--- a/src/Gui/ConfigDialog.cs
+++ b/src/Gui/ConfigDialog.cs
@@ -206,6 +206,22 @@ namespace RPVoiceChat
 
             RegisterOption(new ConfigOption
             {
+                Text = "Players Volume Level",
+                SliderKey = "outputGain",
+                Tooltip = "How much to increase volume of other players",
+                SlideAction = SlideOutputGain
+            });
+
+            RegisterOption(new ConfigOption
+            {
+                Text = "Recording Volume",
+                SliderKey = "inputGain",
+                Tooltip = "Changes your own volume",
+                SlideAction = SlideInputGain
+            });
+
+            RegisterOption(new ConfigOption
+            {
                 Text = "Audio Input Threshold",
                 SliderKey = "inputThreshold",
                 Tooltip = "At which threshold your audio starts transmitting",
@@ -236,6 +252,8 @@ namespace RPVoiceChat
             SingleComposer.GetSwitch("togglePushToTalk").On = _config.PushToTalkEnabled;
             SingleComposer.GetSwitch("muteMicrophone").On = _config.IsMuted;
             SingleComposer.GetSwitch("toggleHUD").On = _config.IsHUDShown;
+            SingleComposer.GetSlider("inputGain").SetValues(_config.InputGain, 0, 100, 1, "%");
+            SingleComposer.GetSlider("outputGain").SetValues(_config.OutputGain, 0, 200, 1, "%");
             SingleComposer.GetSlider("inputThreshold").SetValues(_config.InputThreshold, 0, 100, 1);
             SingleComposer.GetDropDown("inputDevice").SetSelectedValue(_config.CurrentInputDevice);
             SingleComposer.GetSwitch("loopback").On = _config.IsLoopbackEnabled;
@@ -257,6 +275,23 @@ namespace RPVoiceChat
         private void OnChangeInputDevice(string value, bool selected)
         {
             _audioInputManager.SetInputDevice(value);
+        }
+
+        private bool SlideOutputGain(int gain)
+        {
+            _config.OutputGain = gain;
+            ModConfig.Save(capi);
+
+            return true;
+        }
+
+        private bool SlideInputGain(int gain)
+        {
+            _config.InputGain = gain;
+            ModConfig.Save(capi);
+            _audioInputManager.SetGain(gain);
+
+            return true;
         }
 
         private bool SlideInputThreshold(int threshold)

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -31,7 +31,8 @@ namespace RPVoiceChat
         {
             capi = api;
 
-            // Init microphone, audio output and harmony patch managers
+            // Init audio context, microphone, audio output and harmony patch managers
+            OALW.InitContext();
             micManager = new MicrophoneManager(capi);
             audioOutputManager = new AudioOutputManager(capi);
             patchManager = new PatchManager(modID);

--- a/src/Utils/AudioUtils.cs
+++ b/src/Utils/AudioUtils.cs
@@ -1,6 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
-
-namespace RPVoiceChat.Utils
+﻿namespace RPVoiceChat.Utils
 {
     public class AudioUtils
     {
@@ -51,19 +49,5 @@ namespace RPVoiceChat.Utils
 
         //    return filteredAudioData;
         //}
-    }
-
-    public class Util
-    {
-        public static void CheckError(string Value, ALError ignoredErrors = ALError.NoError)
-        {
-            var error = AL.GetError();
-            if (error == ALError.NoError) return;
-
-            if (ignoredErrors == error)
-                return;
-
-            Logger.client.Error("{0} {1}", Value, AL.GetErrorString(error));
-        }
     }
 }


### PR DESCRIPTION
**This PR includes changes from #47, make sure to merge it before this PR**

Adds a slider in the mod settings to adjust volume of other players. Range is from 0% to 200%, default is 200% to match current Mumble settings
Adds a slider in the mod settings to adjust recording volume. Range is from 0% to 100%, default is 100%
Adds a wrapper class around OpenAL to simplify audio context management
Adds a new audio context with default settings
Moves all dynamic audio into the new context 