### PR TITLE
Fix audio crackling

### DIFF
--- a/src/Audio/AudioOutputManager.cs
+++ b/src/Audio/AudioOutputManager.cs
@@ -1,6 +1,5 @@
 ﻿using Vintagestory.API.Client;
 using System.Collections.Concurrent;
-using System.Threading.Tasks;
 using OpenTK.Audio.OpenAL;
 using Vintagestory.API.Common;
 using RPVoiceChat.Networking;
@@ -38,7 +37,6 @@ namespace RPVoiceChat.Audio
         private ConcurrentDictionary<string, PlayerAudioSource> playerSources = new ConcurrentDictionary<string, PlayerAudioSource>();
         private PlayerAudioSource localPlayerAudioSource;
         private PlayerListener listener;
-        private ConcurrentDictionary<string, IAudioCodec> codecs = new ConcurrentDictionary<string, IAudioCodec>();
 
         public AudioOutputManager(ICoreClientAPI api)
         {
@@ -59,53 +57,43 @@ namespace RPVoiceChat.Audio
         }
 
         // Called when the client receives an audio packet supplying the audio packet
-        public async void HandleAudioPacket(AudioPacket packet)
+        public void HandleAudioPacket(AudioPacket packet)
         {
             if (!isReady) return;
-
-            await Task.Run(() =>
+            if (packet.AudioData.Length != packet.Length)
             {
-                PlayerAudioSource source;
-                string playerId = packet.PlayerId;
+                Logger.client.Debug("Audio packet payload had invalid length, dropping packet");
+                return;
+            }
 
-                if (packet.AudioData.Length != packet.Length)
+            PlayerAudioSource source;
+            string playerId = packet.PlayerId;
+
+            if (!playerSources.TryGetValue(playerId, out source))
+            {
+                var player = capi.World.PlayerByUid(playerId);
+                if (player == null)
                 {
-                    Logger.client.Debug("Audio packet payload had invalid length, dropping packet");
+                    Logger.client.Error($"Could not find player for playerId {playerId}");
                     return;
                 }
 
-                if (!playerSources.TryGetValue(playerId, out source))
+                source = new PlayerAudioSource(player, this, capi);
+                if (!playerSources.TryAdd(playerId, source))
                 {
-                    var player = capi.World.PlayerByUid(playerId);
-                    if (player == null)
-                    {
-                        Logger.client.Error($"Could not find player for playerId {playerId}");
-                        return;
-                    }
-
-                    source = new PlayerAudioSource(player, this, capi);
-                    if (!playerSources.TryAdd(playerId, source))
-                    {
-                        Logger.client.Debug("Could not add new player to sources");
-                    }
+                    Logger.client.Debug("Could not add new player to sources");
                 }
+            }
 
-                HandleAudioPacket(packet, source);
-            });
+            HandleAudioPacket(packet, source);
         }
 
         public void HandleAudioPacket(AudioPacket packet, PlayerAudioSource source)
         {
             int frequency = packet.Frequency;
             int channels = AudioUtils.ChannelsPerFormat(packet.Format);
-            string codecSettings = $"{frequency}:{channels}";
 
-            IAudioCodec codec;
-            if (!codecs.TryGetValue(codecSettings, out codec))
-            {
-                codec = new OpusCodec(frequency, channels);
-                codecs.TryAdd(codecSettings, codec);
-            }
+            IAudioCodec codec = source.GetOrCreateAudioCodec(frequency, channels);
             AudioData audioData = AudioData.FromPacket(packet, codec);
 
             // Update the voice level if it has changed

--- a/src/Audio/Codecs/OpusCodec.cs
+++ b/src/Audio/Codecs/OpusCodec.cs
@@ -27,7 +27,7 @@ namespace RPVoiceChat
             encoder.Bitrate = 40000;
             encoder.Complexity = 10;
             encoder.SignalType = OpusSignal.OPUS_SIGNAL_VOICE;
-            encoder.ForceMode = OpusMode.MODE_AUTO;
+            encoder.ForceMode = OpusMode.MODE_SILK_ONLY;
             encoder.UseDTX = false;
             encoder.UseInbandFEC = false;
             encoder.UseVBR = true;
@@ -35,7 +35,7 @@ namespace RPVoiceChat
 
         public byte[] Encode(short[] pcmData)
         {
-            const int maxPacketSize = 1275;
+            const int maxPacketSize = 1276;
             var encoded = new MemoryStream();
 
             try

--- a/src/Audio/Filters/FilterLowpass.cs
+++ b/src/Audio/Filters/FilterLowpass.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTK.Audio.OpenAL;
+using RPVoiceChat.Audio;
 
 namespace RPVoiceChat
 {
@@ -15,10 +16,13 @@ namespace RPVoiceChat
 
         public FilterLowpass(EffectsExtension effectsExtension, int source)
         {
-            this.effectsExtension = effectsExtension;
-            this.source = source;
-            nullFilter = effectsExtension.GenFilter();
-            GenerateFilter();
+            OALW.ExecuteInContext(() =>
+            {
+                this.effectsExtension = effectsExtension;
+                this.source = source;
+                nullFilter = effectsExtension.GenFilter();
+                GenerateFilter();
+            });
         }
 
         /// <summary>
@@ -41,7 +45,7 @@ namespace RPVoiceChat
             if (IsEnabled)
                 return;
 
-            effectsExtension.BindFilterToSource(source, filter);
+            OALW.ExecuteInContext(() => effectsExtension.BindFilterToSource(source, filter));
             IsEnabled = true;
         }
 
@@ -50,7 +54,7 @@ namespace RPVoiceChat
             if (!IsEnabled)
                 return;
 
-            effectsExtension.BindFilterToSource(source, nullFilter);
+            OALW.ExecuteInContext(() => effectsExtension.BindFilterToSource(source, nullFilter));
             IsEnabled = false;
         }
 

--- a/src/Audio/OpenALWrapper.cs
+++ b/src/Audio/OpenALWrapper.cs
@@ -140,6 +140,11 @@ namespace RPVoiceChat.Audio
             });
         }
 
+        public static void ClearError()
+        {
+            AL.GetError();
+        }
+
         public static void CheckError(string Value, ALError ignoredErrors = ALError.NoError)
         {
             var error = AL.GetError();
@@ -148,7 +153,7 @@ namespace RPVoiceChat.Audio
 
             if (_activeContext != context)
             {
-                Logger.client.Error("Calling CheckError outside of mod context is incorrect");
+                Logger.client.Debug($"Calling CheckError outside of mod context is incorrect. Marker of incorrect call: \"{Value}\"");
                 return;
             }
 


### PR DESCRIPTION
Splits one decoder into multiple that are assigned to an audio source
Makes decoding of audio packets synchronous operation to avoid corruption of decoder's internal state
Minor improves to logging and code style 