### PR TITLE
Improve stability of the UDP transport

### DIFF
--- a/src/Client/PlayerNetworkClient.cs
+++ b/src/Client/PlayerNetworkClient.cs
@@ -70,7 +70,6 @@ namespace RPVoiceChat.Client
             if (reserveClient == null)
                 throw new Exception($"Failed to connect to the server. Required transport: {serverConnection.SupportedTransports}");
 
-            Logger.client.Notification($"Using {reserveClient.GetTransportID()} client from now on");
             SwapActiveClient(reserveClient);
             reserveClient = null;
             OnHandshakeRequest(serverConnection);
@@ -78,6 +77,8 @@ namespace RPVoiceChat.Client
 
         private void SwapActiveClient(INetworkClient newClient)
         {
+            Logger.client.Notification($"Using {newClient.GetTransportID()} client from now on");
+            networkClient.Dispose();
             networkClient = newClient;
         }
 

--- a/src/Networking/INetworkClient.cs
+++ b/src/Networking/INetworkClient.cs
@@ -2,7 +2,7 @@
 
 namespace RPVoiceChat.Networking
 {
-    public interface INetworkClient
+    public interface INetworkClient : IDisposable
     {
         public event Action<AudioPacket> OnAudioReceived;
 

--- a/src/Networking/INetworkServer.cs
+++ b/src/Networking/INetworkServer.cs
@@ -8,6 +8,6 @@ namespace RPVoiceChat.Networking
 
         public ConnectionInfo GetConnection();
         public string GetTransportID();
-        public void SendPacket(NetworkPacket packet, string playerId);
+        public bool SendPacket(NetworkPacket packet, string playerId);
     }
 }

--- a/src/Networking/INetworkServer.cs
+++ b/src/Networking/INetworkServer.cs
@@ -2,7 +2,7 @@
 
 namespace RPVoiceChat.Networking
 {
-    public interface INetworkServer
+    public interface INetworkServer : IDisposable
     {
         public event Action<AudioPacket> AudioPacketReceived;
 

--- a/src/Networking/INetworkServer.cs
+++ b/src/Networking/INetworkServer.cs
@@ -4,7 +4,7 @@ namespace RPVoiceChat.Networking
 {
     public interface INetworkServer
     {
-        public event Action<AudioPacket> OnReceivedPacket;
+        public event Action<AudioPacket> AudioPacketReceived;
 
         public ConnectionInfo GetConnection();
         public string GetTransportID();

--- a/src/Networking/INetworkServer.cs
+++ b/src/Networking/INetworkServer.cs
@@ -8,6 +8,6 @@ namespace RPVoiceChat.Networking
 
         public ConnectionInfo GetConnection();
         public string GetTransportID();
-        public void SendPacket(INetworkPacket packet, string playerId);
+        public void SendPacket(NetworkPacket packet, string playerId);
     }
 }

--- a/src/Networking/NativeNetwork/NativeNetworkBase.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkBase.cs
@@ -16,5 +16,10 @@ namespace RPVoiceChat.Networking
         {
             return _transportID;
         }
+
+        public void Dispose()
+        {
+            // Game handles disposal for us
+        }
     }
 }

--- a/src/Networking/NativeNetwork/NativeNetworkServer.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkServer.cs
@@ -5,7 +5,7 @@ namespace RPVoiceChat.Networking
 {
     public class NativeNetworkServer : NativeNetworkBase, INetworkServer
     {
-        public event Action<AudioPacket> OnReceivedPacket;
+        public event Action<AudioPacket> AudioPacketReceived;
         private ICoreServerAPI api;
         private IServerNetworkChannel channel;
 
@@ -29,7 +29,7 @@ namespace RPVoiceChat.Networking
 
         private void ReceivedAudioPacketFromClient(IServerPlayer player, AudioPacket packet)
         {
-            OnReceivedPacket?.Invoke(packet);
+            AudioPacketReceived?.Invoke(packet);
         }
     }
 }

--- a/src/Networking/NativeNetwork/NativeNetworkServer.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkServer.cs
@@ -21,10 +21,11 @@ namespace RPVoiceChat.Networking
             return connectionInfo;
         }
 
-        public void SendPacket(NetworkPacket packet, string playerId)
+        public bool SendPacket(NetworkPacket packet, string playerId)
         {
             var player = api.World.PlayerByUid(playerId) as IServerPlayer;
             channel.SendPacket(packet as AudioPacket, player);
+            return true;
         }
 
         private void ReceivedAudioPacketFromClient(IServerPlayer player, AudioPacket packet)

--- a/src/Networking/NativeNetwork/NativeNetworkServer.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkServer.cs
@@ -21,7 +21,7 @@ namespace RPVoiceChat.Networking
             return connectionInfo;
         }
 
-        public void SendPacket(INetworkPacket packet, string playerId)
+        public void SendPacket(NetworkPacket packet, string playerId)
         {
             var player = api.World.PlayerByUid(playerId) as IServerPlayer;
             channel.SendPacket(packet as AudioPacket, player);

--- a/src/Networking/Packets/AudioPacket.cs
+++ b/src/Networking/Packets/AudioPacket.cs
@@ -1,12 +1,11 @@
 ﻿using OpenTK.Audio.OpenAL;
 using ProtoBuf;
 using RPVoiceChat.Audio;
-using System.IO;
 
 namespace RPVoiceChat.Networking
 {
     [ProtoContract(ImplicitFields = ImplicitFields.AllPublic)]
-    public class AudioPacket : INetworkPacket
+    public class AudioPacket : NetworkPacket
     {
         public string PlayerId { get; set; }
         public byte[] AudioData { get; set; }
@@ -15,6 +14,7 @@ namespace RPVoiceChat.Networking
         public int Frequency { get; set; }
         public ALFormat Format { get; set; }
         public long SequenceNumber { get; set; }
+        protected override PacketType Code { get => PacketType.Audio; }
 
         public AudioPacket() { }
 
@@ -27,24 +27,6 @@ namespace RPVoiceChat.Networking
             Frequency = audioData.frequency;
             Format = audioData.format;
             SequenceNumber = sequenceNumber;
-        }
-
-        public byte[] ToBytes()
-        {
-            var stream = new MemoryStream();
-            Serializer.Serialize(stream, this);
-            return stream.ToArray();
-        }
-
-        INetworkPacket INetworkPacket.FromBytes(byte[] data)
-        {
-            return FromBytes(data);
-        }
-
-        public static AudioPacket FromBytes(byte[] data)
-        {
-            var packet = Serializer.Deserialize<AudioPacket>(new MemoryStream(data));
-            return packet;
         }
     }
 }

--- a/src/Networking/Packets/ConnectionInfo.cs
+++ b/src/Networking/Packets/ConnectionInfo.cs
@@ -1,31 +1,13 @@
 ﻿using ProtoBuf;
-using System.IO;
 
 namespace RPVoiceChat.Networking
 {
     [ProtoContract(ImplicitFields = ImplicitFields.AllPublic)]
-    public class ConnectionInfo : INetworkPacket
+    public class ConnectionInfo : NetworkPacket
     {
         public string Address { get; set; }
         public int Port { get; set; }
         public string[] SupportedTransports { get; set; }
-
-        public byte[] ToBytes()
-        {
-            var stream = new MemoryStream();
-            Serializer.Serialize(stream, this);
-            return stream.ToArray();
-        }
-
-        INetworkPacket INetworkPacket.FromBytes(byte[] data)
-        {
-            return FromBytes(data);
-        }
-
-        public static ConnectionInfo FromBytes(byte[] data)
-        {
-            var packet = Serializer.Deserialize<ConnectionInfo>(new MemoryStream(data));
-            return packet;
-        }
+        protected override PacketType Code { get => PacketType.ConnectionInfo; }
     }
 }

--- a/src/Networking/Packets/INetworkPacket.cs
+++ b/src/Networking/Packets/INetworkPacket.cs
@@ -1,8 +1,0 @@
-﻿namespace RPVoiceChat.Networking
-{
-    public interface INetworkPacket
-    {
-        public byte[] ToBytes();
-        public INetworkPacket FromBytes(byte[] data);
-    }
-}

--- a/src/Networking/Packets/NetworkPacket.cs
+++ b/src/Networking/Packets/NetworkPacket.cs
@@ -1,0 +1,31 @@
+﻿using ProtoBuf;
+using System;
+using System.IO;
+
+namespace RPVoiceChat.Networking
+{
+    public abstract class NetworkPacket
+    {
+        protected abstract PacketType Code { get; }
+
+        public byte[] ToBytes()
+        {
+            var stream = new MemoryStream();
+            stream.Write(BitConverter.GetBytes((int)Code));
+            Serializer.Serialize(stream, this);
+            return stream.ToArray();
+        }
+
+        public static T FromBytes<T>(byte[] data) where T: NetworkPacket
+        {
+            var stream = new MemoryStream(data);
+            PacketType code = (PacketType)BitConverter.ToInt32(data, 0);
+            stream.Position = 4;
+
+            var packet = Serializer.Deserialize<T>(stream);
+            if (code != packet.Code) throw new Exception($"Parsed network packet was of type {code} while expected {packet.Code}");
+
+            return packet;
+        }
+    }
+}

--- a/src/Networking/Packets/PacketType.cs
+++ b/src/Networking/Packets/PacketType.cs
@@ -1,0 +1,11 @@
+﻿namespace RPVoiceChat.Networking
+{
+    public enum PacketType
+    {
+        SelfPing = 0,
+        Ping = 1,
+        Pong = 2,
+        ConnectionInfo = 10,
+        Audio = 20
+    }
+}

--- a/src/Networking/UDPNetwork/UDPNetworkBase.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkBase.cs
@@ -107,28 +107,23 @@ namespace RPVoiceChat.Networking
             return port;
         }
 
-        protected void StartListening(int port)
-        {
-            var endpoint = new IPEndPoint(IPAddress.Any, port);
-            StartListening(endpoint);
-        }
-
-        protected void StartListening(IPEndPoint ipendpoint)
+        protected void StartListening()
         {
             if (UdpClient == null) throw new Exception("Udp client has not been initialized. Can't start listening.");
 
             _listeningCTS = new CancellationTokenSource();
-            _listeningThread = new Thread(() => Listen(ipendpoint, _listeningCTS.Token));
+            _listeningThread = new Thread(() => Listen(_listeningCTS.Token));
             _listeningThread.Start();
         }
 
-        protected void Listen(IPEndPoint ipendpoint, CancellationToken ct)
+        protected void Listen(CancellationToken ct)
         {
             while (_listeningThread.IsAlive && !ct.IsCancellationRequested)
             {
                 try
                 {
-                    byte[] msg = UdpClient.Receive(ref ipendpoint);
+                    IPEndPoint sender = null;
+                    byte[] msg = UdpClient.Receive(ref sender);
 
                     OnMessageReceived?.Invoke(msg);
                 }

--- a/src/Networking/UDPNetwork/UDPNetworkBase.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkBase.cs
@@ -11,7 +11,7 @@ namespace RPVoiceChat.Networking
 {
     public abstract class UDPNetworkBase : IDisposable
     {
-        public event Action<byte[]> OnMessageReceived;
+        public event Action<byte[], IPEndPoint> OnMessageReceived;
 
         private Thread _listeningThread;
         private CancellationTokenSource _listeningCTS;
@@ -125,7 +125,7 @@ namespace RPVoiceChat.Networking
                     IPEndPoint sender = null;
                     byte[] msg = UdpClient.Receive(ref sender);
 
-                    OnMessageReceived?.Invoke(msg);
+                    OnMessageReceived?.Invoke(msg, sender);
                 }
                 catch (SocketException e)
                 {

--- a/src/Networking/UDPNetwork/UDPNetworkBase.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkBase.cs
@@ -59,7 +59,8 @@ namespace RPVoiceChat.Networking
             if (ipParts[0] == 10 ||
                (ipParts[0] == 192 && ipParts[1] == 168) ||
                (ipParts[0] == 172 && (ipParts[1] >= 16 && ipParts[1] <= 31)) ||
-               (ipParts[0] == 25 || ipParts[0] == 26))
+               (ipParts[0] == 25 || ipParts[0] == 26) ||
+               (ipParts[0] == 127 && ipParts[1] == 0 && ipParts[2] == 0 && ipParts[3] == 1))
                 return true;
 
             return false;

--- a/src/Networking/UDPNetwork/UDPNetworkBase.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkBase.cs
@@ -22,6 +22,7 @@ namespace RPVoiceChat.Networking
         protected const string _transportID = "UDP";
         protected bool upnpEnabled = true;
         protected Logger logger;
+        protected bool isReady = false;
 
 
         public string GetTransportID()

--- a/src/Networking/UDPNetwork/UDPNetworkBase.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkBase.cs
@@ -24,6 +24,10 @@ namespace RPVoiceChat.Networking
         protected Logger logger;
         protected bool isReady = false;
 
+        public UDPNetworkBase(Logger logger)
+        {
+            this.logger = logger;
+        }
 
         public string GetTransportID()
         {
@@ -153,6 +157,13 @@ namespace RPVoiceChat.Networking
             string publicIPString = new HttpClient().GetStringAsync("https://ipinfo.io/ip").GetAwaiter().GetResult();
 
             return publicIPString;
+        }
+
+        protected bool AssertEqual(IPEndPoint firstEndPoint, IPEndPoint secondEndPoint)
+        {
+            bool isSameAddress = firstEndPoint.Address.MapToIPv4().ToString() == secondEndPoint.Address.MapToIPv4().ToString();
+            bool isSamePort = firstEndPoint.Port == secondEndPoint.Port;
+            return isSameAddress && isSamePort;
         }
 
         public void Dispose()

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -23,7 +23,7 @@ namespace RPVoiceChat.Networking
 
             if (!IsInternalNetwork(serverConnection.Address))
                 SetupUpnp(port);
-            StartListening(serverEndpoint);
+            StartListening();
 
             var clientConnection = GetConnection();
             return clientConnection;

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -39,7 +39,7 @@ namespace RPVoiceChat.Networking
 
         private void MessageReceived(byte[] msg)
         {
-            AudioPacket packet = AudioPacket.FromBytes(msg);
+            AudioPacket packet = NetworkPacket.FromBytes<AudioPacket>(msg);
             OnAudioReceived?.Invoke(packet);
         }
     }

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -37,7 +37,7 @@ namespace RPVoiceChat.Networking
             UdpClient.Send(data, data.Length, serverEndpoint);
         }
 
-        private void MessageReceived(byte[] msg)
+        private void MessageReceived(byte[] msg, IPEndPoint sender)
         {
             AudioPacket packet = NetworkPacket.FromBytes<AudioPacket>(msg);
             OnAudioReceived?.Invoke(packet);

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -9,9 +9,8 @@ namespace RPVoiceChat.Networking
 
         private IPEndPoint serverEndpoint;
 
-        public UDPNetworkClient()
+        public UDPNetworkClient() : base(Utils.Logger.client)
         {
-            logger = Utils.Logger.client;
 
             OnMessageReceived += MessageReceived;
         }

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -43,12 +43,6 @@ namespace RPVoiceChat.Networking
 
         private void MessageReceived(byte[] msg, IPEndPoint sender)
         {
-            if (!IsServer(sender))
-            {
-                logger.Warning($"Received unauthorized message from {sender}, proceeding to ignore it");
-                return;
-            }
-
             PacketType code = (PacketType)BitConverter.ToInt32(msg, 0);
             switch (code)
             {
@@ -79,11 +73,6 @@ namespace RPVoiceChat.Networking
 
             if (isReady) return;
             throw new Exception("Client failed readiness probe. Aborting to prevent silent malfunction");
-        }
-
-        private bool IsServer(IPEndPoint endPoint)
-        {
-            return AssertEqual(endPoint, serverEndpoint);
         }
     }
 }

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace RPVoiceChat.Networking
 {
@@ -8,9 +10,11 @@ namespace RPVoiceChat.Networking
         public event Action<AudioPacket> OnAudioReceived;
 
         private IPEndPoint serverEndpoint;
+        private CancellationTokenSource _readinessProbeCTS;
 
         public UDPNetworkClient() : base(Utils.Logger.client)
         {
+            _readinessProbeCTS = new CancellationTokenSource();
 
             OnMessageReceived += MessageReceived;
         }
@@ -23,6 +27,7 @@ namespace RPVoiceChat.Networking
             if (!IsInternalNetwork(serverConnection.Address))
                 SetupUpnp(port);
             StartListening();
+            VerifyClientReadiness();
 
             var clientConnection = GetConnection();
             return clientConnection;
@@ -38,8 +43,47 @@ namespace RPVoiceChat.Networking
 
         private void MessageReceived(byte[] msg, IPEndPoint sender)
         {
-            AudioPacket packet = NetworkPacket.FromBytes<AudioPacket>(msg);
-            OnAudioReceived?.Invoke(packet);
+            if (!IsServer(sender))
+            {
+                logger.Warning($"Received unauthorized message from {sender}, proceeding to ignore it");
+                return;
+            }
+
+            PacketType code = (PacketType)BitConverter.ToInt32(msg, 0);
+            switch (code)
+            {
+                case PacketType.Pong:
+                    isReady = true;
+                    _readinessProbeCTS.Cancel();
+                    break;
+                case PacketType.Audio:
+                    AudioPacket packet = NetworkPacket.FromBytes<AudioPacket>(msg);
+                    OnAudioReceived?.Invoke(packet);
+                    break;
+                default:
+                    logger.Error($"Received unsupported packet type: {code}, proceeding to ignore it");
+                    return;
+            }
+        }
+
+        private void VerifyClientReadiness()
+        {
+            var pingPacket = BitConverter.GetBytes((int)PacketType.Ping);
+
+            try
+            {
+                UdpClient.Send(pingPacket, pingPacket.Length, serverEndpoint);
+                Task.Delay(3000, _readinessProbeCTS.Token).GetAwaiter().GetResult();
+            }
+            catch (TaskCanceledException) { }
+
+            if (isReady) return;
+            throw new Exception("Client failed readiness probe. Aborting to prevent silent malfunction");
+        }
+
+        private bool IsServer(IPEndPoint endPoint)
+        {
+            return AssertEqual(endPoint, serverEndpoint);
         }
     }
 }

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -75,8 +75,7 @@ namespace RPVoiceChat.Networking
             switch (code)
             {
                 case PacketType.SelfPing:
-                    bool isAuthentic = ownEndPoint.Address == sender.Address && ownEndPoint.Port == sender.Port;
-                    if (!isAuthentic) return;
+                    if (!IsSelf(sender)) return;
                     isReady = true;
                     break;
                 case PacketType.Audio:
@@ -97,6 +96,13 @@ namespace RPVoiceChat.Networking
 
             if (isReady) return;
             throw new Exception("Server failed readiness probe. Aborting to prevent silent malfunction");
+        }
+
+        private bool IsSelf(IPEndPoint endPoint)
+        {
+            bool isSameAddress = ownEndPoint.Address.MapToIPv4().ToString() == endPoint.Address.MapToIPv4().ToString();
+            bool isSamePort = ownEndPoint.Port == endPoint.Port;
+            return isSameAddress && isSamePort;
         }
     }
 }

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -41,7 +41,7 @@ namespace RPVoiceChat.Networking
             return connectionInfo;
         }
 
-        public void SendPacket(INetworkPacket packet, string playerId)
+        public void SendPacket(NetworkPacket packet, string playerId)
         {
             ConnectionInfo connectionInfo;
             if (!connectionsByPlayer.TryGetValue(playerId, out connectionInfo))

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -6,7 +6,7 @@ namespace RPVoiceChat.Networking
 {
     public class UDPNetworkServer : UDPNetworkBase, IExtendedNetworkServer
     {
-        public event Action<AudioPacket> OnReceivedPacket;
+        public event Action<AudioPacket> AudioPacketReceived;
 
         private Dictionary<string, ConnectionInfo> connectionsByPlayer = new Dictionary<string, ConnectionInfo>();
         private IPAddress ip;

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -67,8 +67,16 @@ namespace RPVoiceChat.Networking
 
         private void MessageReceived(byte[] msg)
         {
-            var packet = AudioPacket.FromBytes(msg);
-            OnReceivedPacket?.Invoke(packet);
+            PacketType code = (PacketType)BitConverter.ToInt32(msg, 0);
+            switch (code)
+            {
+                case PacketType.Audio:
+                    var packet = NetworkPacket.FromBytes<AudioPacket>(msg);
+                    AudioPacketReceived?.Invoke(packet);
+                    break;
+                default:
+                    throw new Exception($"Unsupported packet type: {code}");
+            }
         }
     }
 }

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -13,12 +13,11 @@ namespace RPVoiceChat.Networking
         private IPAddress ip;
         private IPEndPoint ownEndPoint;
 
-        public UDPNetworkServer(int port, string ip = null)
+        public UDPNetworkServer(int port, string ip = null) : base(Utils.Logger.server)
         {
             this.port = port;
             this.ip = IPAddress.Parse(ip ?? GetPublicIP());
             ownEndPoint = GetEndPoint(GetConnection());
-            logger = Utils.Logger.server;
 
             OnMessageReceived += MessageReceived;
         }
@@ -100,9 +99,7 @@ namespace RPVoiceChat.Networking
 
         private bool IsSelf(IPEndPoint endPoint)
         {
-            bool isSameAddress = ownEndPoint.Address.MapToIPv4().ToString() == endPoint.Address.MapToIPv4().ToString();
-            bool isSamePort = ownEndPoint.Port == endPoint.Port;
-            return isSameAddress && isSamePort;
+            return AssertEqual(endPoint, ownEndPoint);
         }
     }
 }

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -26,7 +26,7 @@ namespace RPVoiceChat.Networking
             if (!IsInternalNetwork(ip))
                 SetupUpnp(port);
             OpenUDPClient(port);
-            StartListening(port);
+            StartListening();
             VerifyServerReadiness();
         }
 

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -47,16 +47,16 @@ namespace RPVoiceChat.Networking
             return connectionInfo;
         }
 
-        public void SendPacket(NetworkPacket packet, string playerId)
+        public bool SendPacket(NetworkPacket packet, string playerId)
         {
             ConnectionInfo connectionInfo;
-            if (!connectionsByPlayer.TryGetValue(playerId, out connectionInfo))
-                throw new Exception($"Player {playerId} is not connected to the server");
+            if (!connectionsByPlayer.TryGetValue(playerId, out connectionInfo)) return false;
 
             var data = packet.ToBytes();
             var destination = GetEndPoint(connectionInfo);
 
             UdpClient.Send(data, data.Length, destination);
+            return true;
         }
 
         public void PlayerConnected(string playerId, ConnectionInfo connectionInfo)
@@ -67,6 +67,7 @@ namespace RPVoiceChat.Networking
 
         public void PlayerDisconnected(string playerId)
         {
+            if (!connectionsByPlayer.ContainsKey(playerId)) return;
             connectionsByPlayer.Remove(playerId);
             logger.VerboseDebug($"{playerId} disconnected from UDP server");
         }

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -67,7 +67,7 @@ namespace RPVoiceChat.Networking
             logger.VerboseDebug($"{playerId} disconnected from UDP server");
         }
 
-        private void MessageReceived(byte[] msg)
+        private void MessageReceived(byte[] msg, IPEndPoint sender)
         {
             PacketType code = (PacketType)BitConverter.ToInt32(msg, 0);
             switch (code)

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -22,6 +22,7 @@ namespace RPVoiceChat
 
         private ModMenuDialog configGui;
 
+        private bool isReady = false;
         private bool mutePressed = false;
         private bool voiceMenuPressed = false;
         private bool voiceLevelPressed = false;
@@ -112,6 +113,7 @@ namespace RPVoiceChat
             micManager.OnBufferRecorded += OnBufferRecorded;
             micManager.Launch();
             audioOutputManager.Launch();
+            isReady = true;
         }
 
         private void Event_KeyUp(KeyEvent e)
@@ -128,6 +130,7 @@ namespace RPVoiceChat
 
         private void OnAudioReceived(AudioPacket packet)
         {
+            if (!isReady) return;
             audioOutputManager.HandleAudioPacket(packet);
         }
 

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -137,8 +137,8 @@ namespace RPVoiceChat.Server
         {
             try
             {
-                networkServer.SendPacket(packet, playerId);
-                return;
+                bool success = networkServer.SendPacket(packet, playerId);
+                if (success) return;
             }
             catch (Exception e)
             {
@@ -147,12 +147,15 @@ namespace RPVoiceChat.Server
 
             try
             {
-                reserveServer?.SendPacket(packet, playerId);
+                bool success = reserveServer?.SendPacket(packet, playerId) ?? false;
+                if (success) return;
             }
             catch (Exception e)
             {
                 Logger.server.VerboseDebug($"Couldn't use backup server to deliver a packet to {playerId}: {e.Message}");
             }
+
+            Logger.server.Error($"Failed to deliver a packet to {playerId}: All servers refused to serve the client");
         }
 
         public void Dispose()

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -40,13 +40,13 @@ namespace RPVoiceChat.Server
                 extendedServer?.Launch();
                 api.Event.PlayerNowPlaying += PlayerJoined;
                 api.Event.PlayerDisconnect += PlayerLeft;
-                networkServer.OnReceivedPacket += SendAudioToAllClientsInRange;
+                networkServer.AudioPacketReceived += SendAudioToAllClientsInRange;
                 serverByTransport.Add(networkServer.GetTransportID(), networkServer);
                 Logger.server.Notification($"{networkServer.GetTransportID()} server started");
 
                 if (reserveServer == null) return;
                 Logger.server.Notification($"Launching {reserveServer.GetTransportID()} server");
-                reserveServer.OnReceivedPacket += SendAudioToAllClientsInRange;
+                reserveServer.AudioPacketReceived += SendAudioToAllClientsInRange;
                 serverByTransport.Add(reserveServer.GetTransportID(), reserveServer);
                 Logger.server.Notification($"{reserveServer.GetTransportID()} server started");
                 return;

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -131,7 +131,7 @@ namespace RPVoiceChat.Server
             }
         }
 
-        private void SendPacket(INetworkPacket packet, string playerId)
+        private void SendPacket(NetworkPacket packet, string playerId)
         {
             try
             {

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -82,18 +82,19 @@ namespace RPVoiceChat.Server
 
         public void SendAudioToAllClientsInRange(AudioPacket packet)
         {
-            var player = api.World.PlayerByUid(packet.PlayerId);
+            var transmittingPlayer = api.World.PlayerByUid(packet.PlayerId);
             int distance = WorldConfig.GetInt(packet.VoiceLevel);
             int squareDistance = distance * distance;
 
-            foreach (var closePlayer in api.World.AllOnlinePlayers)
+            foreach (IServerPlayer player in api.World.AllOnlinePlayers)
             {
-                if (closePlayer == player ||
-                    closePlayer.Entity == null ||
-                    player.Entity.Pos.SquareDistanceTo(closePlayer.Entity.Pos.XYZ) > squareDistance)
+                if (player == transmittingPlayer ||
+                    player.Entity == null ||
+                    player.ConnectionState != EnumClientState.Playing ||
+                    transmittingPlayer.Entity.Pos.SquareDistanceTo(player.Entity.Pos.XYZ) > squareDistance)
                     continue;
 
-                SendPacket(packet, closePlayer.PlayerUID);
+                SendPacket(packet, player.PlayerUID);
             }
         }
 

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -64,7 +64,6 @@ namespace RPVoiceChat.Server
             if (reserveServer == null)
                 throw new Exception("Failed to launch any server");
 
-            Logger.server.Notification($"Using {reserveServer.GetTransportID()} server from now on");
             SwapActiveServer(reserveServer);
             reserveServer = null;
             Launch();
@@ -100,6 +99,7 @@ namespace RPVoiceChat.Server
 
         private void SwapActiveServer(INetworkServer newTransport)
         {
+            Logger.server.Notification($"Using {newTransport.GetTransportID()} server from now on");
             networkServer = newTransport;
         }
 

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -100,6 +100,7 @@ namespace RPVoiceChat.Server
         private void SwapActiveServer(INetworkServer newTransport)
         {
             Logger.server.Notification($"Using {newTransport.GetTransportID()} server from now on");
+            networkServer.Dispose();
             networkServer = newTransport;
         }
 


### PR DESCRIPTION
Adds support for different packet type to the UDP transport
Adds health-check for UDP server and UDP client. Server pings its own IP, while client pings server and waits for the reply.
Adds `127.0.0.1` to the list of addresses for which UPnP is disabled
Fixes a bug causing game process remain active if transport downgrade happened during connection to the server
Prevents server from sending audio to clients before they connect to the world
Discards audio packets received by client if it wasn't ready to process them
Small code refactoring
Logging improvements