### PR TITLE
Fix packet ordering issues 

### DIFF
--- a/src/Audio/AudioData.cs
+++ b/src/Audio/AudioData.cs
@@ -13,13 +13,11 @@ namespace RPVoiceChat.Audio
 
         public AudioData() { }
 
-        public static AudioData FromPacket(AudioPacket audioPacket, IAudioCodec codec = null)
+        public static AudioData FromPacket(AudioPacket audioPacket)
         {
-            var data = codec?.Decode(audioPacket.AudioData) ?? audioPacket.AudioData;
-
             return new AudioData()
             {
-                data = data,
+                data = audioPacket.AudioData,
                 frequency = audioPacket.Frequency,
                 format = audioPacket.Format,
                 voiceLevel = audioPacket.VoiceLevel,

--- a/src/Audio/Codecs/IAudioCodec.cs
+++ b/src/Audio/Codecs/IAudioCodec.cs
@@ -2,8 +2,10 @@
 {
     public interface IAudioCodec
     {
+        public int SampleRate { get; }
+        public int Channels { get; }
+        public int FrameSize { get; }
         public byte[] Encode(short[] pcmData);
         public byte[] Decode(byte[] encodedData);
-        public int GetFrameSize();
     }
 }

--- a/src/Audio/Codecs/OpusCodec.cs
+++ b/src/Audio/Codecs/OpusCodec.cs
@@ -23,7 +23,7 @@ namespace RPVoiceChat.Audio
             encoder = new OpusEncoder(SampleRate, Channels, OpusApplication.OPUS_APPLICATION_VOIP);
             decoder = new OpusDecoder(SampleRate, Channels);
 
-            encoder.Bitrate = 40000;
+            encoder.Bitrate = 40 * 1024;
             encoder.Complexity = 10;
             encoder.SignalType = OpusSignal.OPUS_SIGNAL_VOICE;
             encoder.ForceMode = OpusMode.MODE_SILK_ONLY;

--- a/src/Audio/Input/MicrophoneManager.cs
+++ b/src/Audio/Input/MicrophoneManager.cs
@@ -121,7 +121,7 @@ namespace RPVoiceChat.Audio
             if (clientEntity == null || capture == null) return;
 
             int samplesAvailable = capture.AvailableSamples;
-            int frameSize = codec.GetFrameSize();
+            int frameSize = codec.FrameSize;
             int samplesToRead = samplesAvailable - samplesAvailable % frameSize;
             if (samplesToRead <= 0) return;
             int bufferLength = samplesToRead * SampleToByte * InputChannelCount;

--- a/src/Audio/Output/AudioOutputManager.cs
+++ b/src/Audio/Output/AudioOutputManager.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.DB;
+using RPVoiceChat.DB;
 using RPVoiceChat.Networking;
 using RPVoiceChat.Utils;
 using System;
@@ -64,19 +64,11 @@ namespace RPVoiceChat.Audio
                 return;
             }
 
-            PlayerAudioSource source;
-            string playerId = packet.PlayerId;
-
-            if (!playerSources.TryGetValue(playerId, out source) || source.IsDisposed)
+            PlayerAudioSource source = GetOrCreatePlayerSource(packet.PlayerId);
+            if (source == null)
             {
-                var player = capi.World.PlayerByUid(playerId);
-                if (player == null)
-                {
-                    Logger.client.Error($"Could not find player for playerId {playerId}");
-                    return;
-                }
-
-                source = CreatePlayerSource(player);
+                Logger.client.Debug("Unable to resolve player ID into player source, dropping packet");
+                return;
             }
 
             HandleAudioPacket(packet, source);
@@ -111,6 +103,18 @@ namespace RPVoiceChat.Audio
 
             if (!isLoopbackEnabled) return;
             localPlayerAudioSource.StartPlaying();
+        }
+
+        private PlayerAudioSource GetOrCreatePlayerSource(string playerId)
+        {
+            PlayerAudioSource source;
+            if (playerSources.TryGetValue(playerId, out source) && !source.IsDisposed)
+                return source;
+
+            var player = capi.World.PlayerByUid(playerId);
+            if (player == null) return null;
+
+            return CreatePlayerSource(player);
         }
 
         private PlayerAudioSource CreatePlayerSource(IPlayer player)

--- a/src/Audio/Output/AudioOutputManager.cs
+++ b/src/Audio/Output/AudioOutputManager.cs
@@ -86,14 +86,12 @@ namespace RPVoiceChat.Audio
         {
             int frequency = packet.Frequency;
             int channels = AudioUtils.ChannelsPerFormat(packet.Format);
+            AudioData audioData = AudioData.FromPacket(packet);
 
-            IAudioCodec codec = source.GetOrCreateAudioCodec(frequency, channels);
-            AudioData audioData = AudioData.FromPacket(packet, codec);
-
-            // Update the voice level if it has changed
             if (source.voiceLevel != packet.VoiceLevel)
                 source.UpdateVoiceLevel(packet.VoiceLevel);
             source.UpdatePlayer();
+            source.UpdateAudioFormat(frequency, channels);
             source.EnqueueAudio(audioData, packet.SequenceNumber);
         }
 

--- a/src/Audio/Output/PlayerAudioSource.cs
+++ b/src/Audio/Output/PlayerAudioSource.cs
@@ -202,13 +202,13 @@ namespace RPVoiceChat.Audio
         {
             if (orderingQueue.ContainsKey(sequenceNumber))
             {
-                Logger.client.Debug("Audio sequence already received, skipping enqueueing");
+                Logger.client.VerboseDebug($"Audio sequence {sequenceNumber} already received, skipping enqueueing");
                 return;
             }
 
-            if (lastAudioSequenceNumber > sequenceNumber)
+            if (lastAudioSequenceNumber >= sequenceNumber)
             {
-                Logger.client.Debug("Audio sequence arrived too late, skipping enqueueing");
+                Logger.client.VerboseDebug($"Audio sequence {sequenceNumber} arrived too late, skipping enqueueing");
                 return;
             }
 

--- a/src/Utils/Logger.cs
+++ b/src/Utils/Logger.cs
@@ -9,6 +9,8 @@ namespace RPVoiceChat.Utils
         public ICoreAPI api;
         public static Logger server;
         public static Logger client;
+        private object debug_file_lock = new object();
+        private object main_file_lock = new object();
 
         public Logger(ICoreAPI api)
         {
@@ -24,8 +26,8 @@ namespace RPVoiceChat.Utils
 
         public void Error(string message, params object[] args)
         {
-            api.Logger.Error($"[RPVoiceChat] {message}", args);
-            api.Logger.VerboseDebug($"[Error] [RPVoiceChat] {message}", args);
+            lock (main_file_lock) api.Logger.Error($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger.VerboseDebug($"[Error] [RPVoiceChat] {message}", args);
         }
 
         public void Debug(string message)
@@ -35,7 +37,7 @@ namespace RPVoiceChat.Utils
 
         public void Debug(string message, params object[] args)
         {
-            api.Logger.Debug($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger.Debug($"[RPVoiceChat] {message}", args);
         }
 
         public void VerboseDebug(string message)
@@ -45,7 +47,7 @@ namespace RPVoiceChat.Utils
 
         public void VerboseDebug(string message, params object[] args)
         {
-            api.Logger.VerboseDebug($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger.VerboseDebug($"[RPVoiceChat] {message}", args);
         }
 
         public void Warning(string message)
@@ -55,8 +57,8 @@ namespace RPVoiceChat.Utils
 
         public void Warning(string message, params object[] args)
         {
-            api.Logger.Warning($"[RPVoiceChat] {message}", args);
-            api.Logger.VerboseDebug($"[Warning] [RPVoiceChat] {message}", args);
+            lock (main_file_lock) api.Logger.Warning($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger.VerboseDebug($"[Warning] [RPVoiceChat] {message}", args);
         }
 
         public void Notification(string message)
@@ -66,8 +68,8 @@ namespace RPVoiceChat.Utils
 
         public void Notification(string message, params object[] args)
         {
-            api.Logger.Notification($"[RPVoiceChat] {message}", args);
-            api.Logger.VerboseDebug($"[Notification] [RPVoiceChat] {message}", args);
+            lock (main_file_lock) api.Logger.Notification($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger.VerboseDebug($"[Notification] [RPVoiceChat] {message}", args);
         }
     }
 }


### PR DESCRIPTION
- Fixes corrupted/abnormal Opus decoder state caused by decoding packets before reordering them. Enforcing correct packet order requires regression to single thread which will increase the amount of time it takes for decoding all audio, may increase delay before playing first audio packet after silence or cause discontinuous audio if decoding packet takes longer than playing it (shouldn't be the case unless decoding thread is overloaded while the one used by OpenAL isn't).
- Fixes corrupted log entries that were appearing due to multi-threading
- Increases bitrate ceiling to a maximum supported by SILK codec
- Decreases `OpusCodec` memory usage by reusing encoding/decoding buffers instead of reallocating them for every audio frame. Should also insignificantly speed up Garbage Collection.
- Small code refactoring