### PR TITLE
Improve stability of the TCP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Not only does the mod allow players to talk to each other in-game, but it also a
 1. Download the latest version of the mod from the [mod page](https://mods.vintagestory.at/rpvoicechat).
 2. Place the downloaded file in the `Mods` folder of your Vintage Story installation.
 3. Start the game and enjoy!
-4. (Optional): Double check your keybinds in the settings menu. All keybinds start with `RPVC` and are located in the hud and interface category.
+4. (Optional): Double check your keybinds in the settings menu. All keybinds start with `RPVoice` and are located in the hud and interface category.
  
 ## Usage
 ### Talking
@@ -33,8 +33,9 @@ You can configure your microphone volume and the volume of everyone else in your
 
 ## <a name="configuration-users"></a>Configuration (For users)
 The mod is highly configurable and can be configured more deeply in the modconfig file. You'll find this file in the `ModConfig` folder in the same directory as your `Mods` folder. The file is called `rpvoicechat.json`.
+
 The settings relevant to users are:
-- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. **Setting this to true means that you take full responsibility for opening ports and if they are not open mod will work incorrectly.** The default value is `false`.
+- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. The default value is `false`.
 - `PushToTalkEnabled` - Whether push to talk is enabled. The default value is `false`.
 - `IsLoopbackEnabled` - The setting that defines whether you should be able to hear what you're transmitting. The default value is `false`.
 - `IsDenoisingEnabled` - Whether or not your audio should be denoised. The default value is `false`.
@@ -43,17 +44,27 @@ The settings relevant to users are:
 - `OutputGain` - The volume level of other players in percent (0-300). The default value is `100`.
 - `InputGain` - The volume level of your microphone in percent (0-200). The default value is `100`.
 - `InputThreshold` - The current setting of your audio input threshold in percent (0-100). The default value is `20`.
-- `MaxInputThreshold` - This configures how finely tuned the input threshold should be. The smaller number the more sensitive the input will be. The default value is `0.24`.
 - `BackgroungNoiseThreshold` - Sensitivity of the denoiser in percent (0-100). 0 means all audio is voice, 100 means all audio is noise. If audio is detected as noise it will be denoised at max strength. The default value is `50`.
 - `VoiceDenoisingStrength` - Intensity of voice denoising in percent (0-100). Low value won't remove noise when you are speaking, high value may decrease audio quality. The default value is `80`.
+- `MaxInputThreshold` - This configures how finely tuned the input threshold should be. The smaller number the more sensitive the input will be. The default value is `0.24`.
  
 ## <a name="configuration-server"></a>Configuration (For server owners)
 The mod is highly configurable and can be configured more deeply in the modconfig file. You'll find this file in the `ModConfig` folder in the same directory as your `Mods` folder. The file is called `rpvoicechat.json`.
+
 The settings relevant to server owners are:
-- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. **Setting this to true means that you take full responsibility for opening ports and if they are not open mod will work incorrectly.** The default value is `false`.
-- `ServerPort` - The port to use for the voice networking if ports are being forwarded manually. The default value is `52525`.
-- `ServerIP` - The ip to send to clients to connect to if manually port forwarding. The default value is `null`.
+- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. The default value is `false`.
+- `ServerPort` - The port to use for the voice networking. The default value is `52525`.
+- `ServerIP` - The ip for clients to connect to. Leave it as is unless you are playing through LAN, in which case set it to address of your private network(e.g. `"25.95.127.13"`). The default value is `null`.
 - `AdditionalContent` - Whether additional modded content(bells, horns, etc) should be enabled. The default value is `true`.
+
+You can also use `/rpvc [command]` to access world-specific settings:
+- `shout` - Sets the shout distance in blocks. The default value is `25`.
+- `talk` - Sets the talk distance in blocks. The default value is `15`.
+- `whisper` - Sets the whisper distance in blocks. The default value is `5`.
+- `reset` - Resets the audio distances to their default settings.
+- `info` - Displays current audio distances and states of toggles.
+- `forcenametags` - If you use mods that hide player name tags you can disable this setting to keep them hidden. The default value is `true`.
+- `encodeaudio` - If you encounter distorted/out of order audio you can disable thus setting and see if it helps. **Be aware that this will drastically increase bandwidth usage for everyone on the server.** The default value is `true`.
 
 ## Maintainers
 Currently the mod is maintained by the following people:

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
     "description": "A mod that adds in game voice proximity chat!",
-    "version": "2.3.0"
+    "version": "2.3.1"
 }

--- a/src/Audio/AudioData.cs
+++ b/src/Audio/AudioData.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using RPVoiceChat.Networking;
 
 namespace RPVoiceChat.Audio

--- a/src/Audio/Codecs/IAudioCodec.cs
+++ b/src/Audio/Codecs/IAudioCodec.cs
@@ -1,4 +1,4 @@
-﻿namespace RPVoiceChat.Audio
+namespace RPVoiceChat.Audio
 {
     public interface IAudioCodec
     {

--- a/src/Audio/Codecs/OpusCodec.cs
+++ b/src/Audio/Codecs/OpusCodec.cs
@@ -1,4 +1,4 @@
-﻿using Concentus.Enums;
+using Concentus.Enums;
 using Concentus.Structs;
 using RPVoiceChat.Utils;
 using System;

--- a/src/Audio/Effects/Denoisers/IDenoiser.cs
+++ b/src/Audio/Effects/Denoisers/IDenoiser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RPVoiceChat.Audio.Effects
 {

--- a/src/Audio/Effects/Denoisers/RNNoise.cs
+++ b/src/Audio/Effects/Denoisers/RNNoise.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace RPVoiceChat.Audio.Effects

--- a/src/Audio/Effects/Denoisers/RNNoiseDenoiser.cs
+++ b/src/Audio/Effects/Denoisers/RNNoiseDenoiser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using Vintagestory.API.MathTools;
 

--- a/src/Audio/Effects/EffectReverb.cs
+++ b/src/Audio/Effects/EffectReverb.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 
 namespace RPVoiceChat.Audio.Effects
 {

--- a/src/Audio/Effects/EffectTemplate.cs
+++ b/src/Audio/Effects/EffectTemplate.cs
@@ -1,4 +1,4 @@
-﻿namespace RPVoiceChat.Audio.Effects
+namespace RPVoiceChat.Audio.Effects
 {
     public class EffectTemplate
     {

--- a/src/Audio/Effects/Filters/FilterLowpass.cs
+++ b/src/Audio/Effects/Filters/FilterLowpass.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 
 namespace RPVoiceChat.Audio.Effects
 {

--- a/src/Audio/Input/IAudioCapture.cs
+++ b/src/Audio/Input/IAudioCapture.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using System;
 using System.Collections.Generic;
 

--- a/src/Audio/Input/MicrophoneManager.cs
+++ b/src/Audio/Input/MicrophoneManager.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using RPVoiceChat.Audio.Effects;
 using RPVoiceChat.Utils;
 using System;

--- a/src/Audio/Input/OpenALAudioCapture.cs
+++ b/src/Audio/Input/OpenALAudioCapture.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using RPVoiceChat.Utils;
 using System;
 using System.Collections.Generic;

--- a/src/Audio/OpenALWrapper.cs
+++ b/src/Audio/OpenALWrapper.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using RPVoiceChat.Utils;
 
 namespace RPVoiceChat.Audio

--- a/src/Audio/Output/CircularAudioBufer.cs
+++ b/src/Audio/Output/CircularAudioBufer.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using RPVoiceChat.Utils;
 using System;
 using System.Collections.Generic;

--- a/src/Audio/Output/PlayerAudioSource.cs
+++ b/src/Audio/Output/PlayerAudioSource.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using RPVoiceChat.Audio.Effects;
 using RPVoiceChat.DB;
 using RPVoiceChat.Gui;

--- a/src/Audio/Output/PlayerListener.cs
+++ b/src/Audio/Output/PlayerListener.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using Vintagestory.API.Client;
 
 namespace RPVoiceChat.Audio

--- a/src/Blocks/SoundEmittingBlock.cs
+++ b/src/Blocks/SoundEmittingBlock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Vintagestory.API.Common;
 
 namespace RPVoiceChat

--- a/src/Client/PlayerNetworkClient.cs
+++ b/src/Client/PlayerNetworkClient.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Networking;
+using RPVoiceChat.Networking;
 using RPVoiceChat.Utils;
 using System;
 using System.Collections.Generic;

--- a/src/Config/ClientSettings.cs
+++ b/src/Config/ClientSettings.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Client;
+using Vintagestory.API.Client;
 
 namespace RPVoiceChat
 {

--- a/src/Config/ModConfig.cs
+++ b/src/Config/ModConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Vintagestory.API.Common;
 
 namespace RPVoiceChat

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace RPVoiceChat
+namespace RPVoiceChat
 {
     public class RPVoiceChatConfig
     {

--- a/src/Config/WorldConfig.cs
+++ b/src/Config/WorldConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Vintagestory.API.Common;
 
 namespace RPVoiceChat

--- a/src/DB/ClientSettingsRepository.cs
+++ b/src/DB/ClientSettingsRepository.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
 using Vintagestory.API.Common;

--- a/src/DB/DataRepository.cs
+++ b/src/DB/DataRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.SQLite;
 using System.IO;
 using Vintagestory.API.Common;

--- a/src/DB/SQLiteDB.cs
+++ b/src/DB/SQLiteDB.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.SQLite;
 using Vintagestory.API.Common;
 

--- a/src/Gui/CustomElements/AudioMeter.cs
+++ b/src/Gui/CustomElements/AudioMeter.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Audio;
+using RPVoiceChat.Audio;
 using System;
 using Vintagestory.API.Client;
 

--- a/src/Gui/CustomElements/IExtendedGuiElement.cs
+++ b/src/Gui/CustomElements/IExtendedGuiElement.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Client;
+using Vintagestory.API.Client;
 
 namespace RPVoiceChat.Gui
 {

--- a/src/Gui/CustomElements/NamedSlider.cs
+++ b/src/Gui/CustomElements/NamedSlider.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Client;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 
 namespace RPVoiceChat.Gui

--- a/src/Gui/CustomElements/PlayerList.cs
+++ b/src/Gui/CustomElements/PlayerList.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.DB;
+using RPVoiceChat.DB;
 using RPVoiceChat.Utils;
 using System.Linq;
 using Vintagestory.API.Client;

--- a/src/Gui/Hud/SpeechIndicator.cs
+++ b/src/Gui/Hud/SpeechIndicator.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Audio;
+using RPVoiceChat.Audio;
 using System;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;

--- a/src/Gui/Hud/VoiceLevelIcon.cs
+++ b/src/Gui/Hud/VoiceLevelIcon.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Audio;
+using RPVoiceChat.Audio;
 using System;
 using System.Collections.Generic;
 using Vintagestory.API.Client;

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Audio;
+using RPVoiceChat.Audio;
 using RPVoiceChat.DB;
 using RPVoiceChat.Utils;
 using System;

--- a/src/Gui/PlayerNameTagRenderer.cs
+++ b/src/Gui/PlayerNameTagRenderer.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Audio;
+using RPVoiceChat.Audio;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;

--- a/src/Items/RadioItem.cs
+++ b/src/Items/RadioItem.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Common;
+using Vintagestory.API.Common;
 
 namespace RPVoiceChat
 {

--- a/src/Items/SoundEmittingItem.cs
+++ b/src/Items/SoundEmittingItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 

--- a/src/Items/TelegraphWireItem.cs
+++ b/src/Items/TelegraphWireItem.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Common;
+using Vintagestory.API.Common;
 
 namespace RPVoiceChat
 {

--- a/src/Networking/HealthCheckException.cs
+++ b/src/Networking/HealthCheckException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace RPVoiceChat.Networking
+{
+    public class HealthCheckException : Exception
+    {
+        private const string msg = "failed readiness probe. Aborting to prevent silent malfunction.";
+        public override string StackTrace => null;
+
+        public HealthCheckException(NetworkSide side) : base($"{side} {msg}") { }
+    }
+}

--- a/src/Networking/IExtendedNetworkClient.cs
+++ b/src/Networking/IExtendedNetworkClient.cs
@@ -4,7 +4,7 @@ namespace RPVoiceChat.Networking
 {
     public interface IExtendedNetworkClient : INetworkClient
     {
-        public event Action<bool> OnConnectionLost;
+        public event Action<bool, IExtendedNetworkClient> OnConnectionLost;
 
         public ConnectionInfo Connect(ConnectionInfo serverConnection);
     }

--- a/src/Networking/IExtendedNetworkServer.cs
+++ b/src/Networking/IExtendedNetworkServer.cs
@@ -1,4 +1,4 @@
-﻿namespace RPVoiceChat.Networking
+namespace RPVoiceChat.Networking
 {
     public interface IExtendedNetworkServer : INetworkServer
     {

--- a/src/Networking/INetworkClient.cs
+++ b/src/Networking/INetworkClient.cs
@@ -7,6 +7,6 @@ namespace RPVoiceChat.Networking
         public event Action<AudioPacket> OnAudioReceived;
 
         public string GetTransportID();
-        public void SendAudioToServer(AudioPacket packet);
+        public bool SendAudioToServer(AudioPacket packet);
     }
 }

--- a/src/Networking/INetworkClient.cs
+++ b/src/Networking/INetworkClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RPVoiceChat.Networking
 {

--- a/src/Networking/INetworkServer.cs
+++ b/src/Networking/INetworkServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RPVoiceChat.Networking
 {

--- a/src/Networking/NativeNetwork/NativeNetworkBase.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkBase.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Common;
+using Vintagestory.API.Common;
 
 namespace RPVoiceChat.Networking
 {

--- a/src/Networking/NativeNetwork/NativeNetworkClient.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkClient.cs
@@ -13,9 +13,10 @@ namespace RPVoiceChat.Networking
             channel = api.Network.GetChannel(ChannelName).SetMessageHandler<AudioPacket>(HandleAudioPacket);
         }
 
-        public void SendAudioToServer(AudioPacket packet)
+        public bool SendAudioToServer(AudioPacket packet)
         {
             channel.SendPacket(packet);
+            return true;
         }
 
         private void HandleAudioPacket(AudioPacket packet)

--- a/src/Networking/NativeNetwork/NativeNetworkClient.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Vintagestory.API.Client;
 
 namespace RPVoiceChat.Networking

--- a/src/Networking/NativeNetwork/NativeNetworkServer.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Vintagestory.API.Server;
 
 namespace RPVoiceChat.Networking

--- a/src/Networking/NetworkSide.cs
+++ b/src/Networking/NetworkSide.cs
@@ -1,0 +1,8 @@
+namespace RPVoiceChat.Networking
+{
+    public enum NetworkSide
+    {
+        Client,
+        Server,
+    }
+}

--- a/src/Networking/Packets/AudioPacket.cs
+++ b/src/Networking/Packets/AudioPacket.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK.Audio.OpenAL;
+using OpenTK.Audio.OpenAL;
 using ProtoBuf;
 using RPVoiceChat.Audio;
 

--- a/src/Networking/Packets/ConnectionInfo.cs
+++ b/src/Networking/Packets/ConnectionInfo.cs
@@ -1,4 +1,4 @@
-﻿using ProtoBuf;
+using ProtoBuf;
 
 namespace RPVoiceChat.Networking
 {

--- a/src/Networking/Packets/NetworkPacket.cs
+++ b/src/Networking/Packets/NetworkPacket.cs
@@ -1,4 +1,4 @@
-﻿using ProtoBuf;
+using ProtoBuf;
 using System;
 using System.IO;
 

--- a/src/Networking/Packets/PacketType.cs
+++ b/src/Networking/Packets/PacketType.cs
@@ -1,4 +1,4 @@
-﻿namespace RPVoiceChat.Networking
+namespace RPVoiceChat.Networking
 {
     public enum PacketType
     {

--- a/src/Networking/TCPNetwork/TCPConnection.cs
+++ b/src/Networking/TCPNetwork/TCPConnection.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Utils;
+using RPVoiceChat.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Networking/TCPNetwork/TCPConnection.cs
+++ b/src/Networking/TCPNetwork/TCPConnection.cs
@@ -156,12 +156,12 @@ namespace RPVoiceChat.Networking
                 {
                     int messageLength = reader.ReadInt32();
                     bytesLeft -= 4;
-                    if (bytesLeft < messageLength || messageLength < 0) break;
+                    if (messageLength > bytesLeft || messageLength < 1) break;
                     byte[] message = reader.ReadBytes(messageLength);
                     messages.Add(message);
                     bytesLeft = stream.Length - stream.Position;
                 }
-                if (bytesLeft != 0) logger.Warning($"Found fragmented packet in message buffer of {remoteEndpoint}. Proceeding to drop it");
+                if (bytesLeft != 0) logger.Warning($"Found fragmented packet in message buffer of {remoteEndpoint}. Proceeding to drop it. (Message queue at {length}/{receiveBuffer.Length})");
             }
             catch (Exception e)
             {

--- a/src/Networking/TCPNetwork/TCPConnection.cs
+++ b/src/Networking/TCPNetwork/TCPConnection.cs
@@ -183,7 +183,11 @@ namespace RPVoiceChat.Networking
 
         public void Disconnect(bool isGraceful = true, bool isHalfClosed = false)
         {
-            try { socket?.Disconnect(true); } catch { }
+            try
+            {
+                socket?.Shutdown(SocketShutdown.Both);
+                socket?.Disconnect(true);
+            } catch { }
             OnDisconnected?.Invoke(isGraceful, isHalfClosed, this);
         }
 

--- a/src/Networking/TCPNetwork/TCPNetworkBase.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkBase.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Utils;
+using RPVoiceChat.Utils;
 using System;
 using System.Threading;
 

--- a/src/Networking/TCPNetwork/TCPNetworkClient.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkClient.cs
@@ -25,17 +25,17 @@ namespace RPVoiceChat.Networking
             return new ConnectionInfo(port);
         }
 
-        public void SendAudioToServer(AudioPacket packet)
+        public bool SendAudioToServer(AudioPacket packet)
         {
-            if (isReady == false)
+            if (isReady == false || connection == null)
             {
                 logger.Warning($"Attempting to send audio over {_transportID} while client isn't ready. Skipping sending.");
-                return;
+                return false;
             }
-            if (connection == null) throw new Exception($"{_transportID} connection has not been initialized.");
 
             var data = packet.ToBytes();
             connection.Send(data);
+            return true;
         }
 
         private TCPConnection OpenConnection(IPEndPoint endPoint)

--- a/src/Networking/TCPNetwork/TCPNetworkClient.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkClient.cs
@@ -93,7 +93,7 @@ namespace RPVoiceChat.Networking
             catch (TaskCanceledException) { }
 
             if (isReady) return;
-            throw new Exception("Client failed readiness probe. Aborting to prevent silent malfunction");
+            throw new HealthCheckException(NetworkSide.Client);
         }
 
         public override void Dispose()

--- a/src/Networking/TCPNetwork/TCPNetworkClient.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkClient.cs
@@ -9,7 +9,7 @@ namespace RPVoiceChat.Networking
     public class TCPNetworkClient : TCPNetworkBase, IExtendedNetworkClient
     {
         public event Action<AudioPacket> OnAudioReceived;
-        public event Action<bool> OnConnectionLost;
+        public event Action<bool, IExtendedNetworkClient> OnConnectionLost;
 
         private IPEndPoint serverEndpoint;
         private TCPConnection connection;
@@ -58,7 +58,7 @@ namespace RPVoiceChat.Networking
             logger.VerboseDebug($"Connection with {_transportID} server was closed {closeType}");
             closedConnection.Dispose();
             bool canReconnect = !isGraceful || isHalfClosed;
-            OnConnectionLost?.Invoke(canReconnect);
+            OnConnectionLost?.Invoke(canReconnect, this);
         }
 
         private void MessageReceived(byte[] msg, TCPConnection _)

--- a/src/Networking/TCPNetwork/TCPNetworkServer.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkServer.cs
@@ -223,7 +223,7 @@ namespace RPVoiceChat.Networking
             catch (TaskCanceledException) { }
 
             if (isReady) return;
-            throw new Exception("Server failed readiness probe. Aborting to prevent silent malfunction");
+            throw new HealthCheckException(NetworkSide.Server);
         }
 
         private TCPConnection ResolveConnection(string playerId)

--- a/src/Networking/TCPNetwork/TCPNetworkServer.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkServer.cs
@@ -176,7 +176,7 @@ namespace RPVoiceChat.Networking
             }
         }
 
-        protected void SetupUpnp(int port)
+        private void SetupUpnp(int port)
         {
             if (!upnpEnabled) return;
 

--- a/src/Networking/UDPNetwork/UDPNetworkBase.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkBase.cs
@@ -1,4 +1,4 @@
-﻿using Open.Nat;
+using Open.Nat;
 using RPVoiceChat.Utils;
 using System;
 using System.Net;
@@ -48,8 +48,7 @@ namespace RPVoiceChat.Networking
                 Task<NatDevice> task = Task.Run(() => discoverer.DiscoverDeviceAsync(PortMapper.Upnp, cts));
                 NatDevice device = task.GetAwaiter().GetResult();
 
-                if (device == null)
-                    throw new NatDeviceNotFoundException("NatDiscoverer have not returned the NatDevice");
+                if (device == null) throw new NatDeviceNotFoundException();
 
                 logger.VerboseDebug("Found a UPnP device, creating port map");
                 device.CreatePortMapAsync(new Mapping(Protocol.Udp, port, port, "Vintage Story Voice Chat"));
@@ -60,7 +59,7 @@ namespace RPVoiceChat.Networking
             }
             catch (NatDeviceNotFoundException)
             {
-                throw new Exception($"Unable to port forward with UPnP. Make sure your IP is public and UPnP is enabled if you want to use {_transportID} connection.");
+                logger.Warning($"Unable to port forward with UPnP, {_transportID} connection may not be available. Make sure your IP is public and UPnP is enabled if you want to use {_transportID} transport.");
             }
         }
 

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -8,7 +8,7 @@ namespace RPVoiceChat.Networking
     public class UDPNetworkClient : UDPNetworkBase, IExtendedNetworkClient
     {
         public event Action<AudioPacket> OnAudioReceived;
-        public event Action<bool> OnConnectionLost = delegate { }; //UDP is connectionless, event should never fire
+        public event Action<bool, IExtendedNetworkClient> OnConnectionLost = delegate { }; //UDP is connectionless, event should never fire
 
         private IPEndPoint serverEndpoint;
 

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -30,12 +30,17 @@ namespace RPVoiceChat.Networking
             return new ConnectionInfo(port);
         }
 
-        public void SendAudioToServer(AudioPacket packet)
+        public bool SendAudioToServer(AudioPacket packet)
         {
-            if (UdpClient == null || serverEndpoint == null) throw new Exception("Udp client or server endpoint has not been initialized.");
+            if (UdpClient == null || serverEndpoint == null)
+            {
+                logger.Warning($"{_transportID} client or server endpoint have not been initialized.");
+                return false;
+            }
 
             var data = packet.ToBytes();
             UdpClient.Send(data, data.Length, serverEndpoint);
+            return true;
         }
 
         private void MessageReceived(byte[] msg, IPEndPoint sender)

--- a/src/Networking/UDPNetwork/UDPNetworkClient.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkClient.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Utils;
+using RPVoiceChat.Utils;
 using System;
 using System.Net;
 using System.Threading.Tasks;
@@ -69,7 +69,7 @@ namespace RPVoiceChat.Networking
             catch (TaskCanceledException) { }
 
             if (isReady) return;
-            throw new Exception("Client failed readiness probe. Aborting to prevent silent malfunction");
+            throw new HealthCheckException(NetworkSide.Client);
         }
     }
 }

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Utils;
+using RPVoiceChat.Utils;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -111,7 +111,7 @@ namespace RPVoiceChat.Networking
             catch (TaskCanceledException) { }
 
             if (isReady) return;
-            throw new Exception("Server failed readiness probe. Aborting to prevent silent malfunction");
+            throw new HealthCheckException(NetworkSide.Server);
         }
 
         private bool IsSelf(IPEndPoint endPoint)

--- a/src/Patches/EntityNameTagRendererRegistry.cs
+++ b/src/Patches/EntityNameTagRendererRegistry.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using RPVoiceChat.Gui;
 using System.Reflection;
 using Vintagestory.API.Client;

--- a/src/Patches/GuiDialogCreateCharacter.cs
+++ b/src/Patches/GuiDialogCreateCharacter.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System;
 using Vintagestory.GameContent;
 

--- a/src/Patches/GuiElementSlider.cs
+++ b/src/Patches/GuiElementSlider.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using RPVoiceChat.Gui;
 using RPVoiceChat.Utils;
 using System.Collections.Generic;

--- a/src/Patches/LoadedSoundNative.cs
+++ b/src/Patches/LoadedSoundNative.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using RPVoiceChat.Audio;
 using System;
 using Vintagestory.Client;

--- a/src/Patches/PatchManager.cs
+++ b/src/Patches/PatchManager.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System;
 
 namespace RPVoiceChat

--- a/src/RPVoiceChatMod.cs
+++ b/src/RPVoiceChatMod.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Utils;
+using RPVoiceChat.Utils;
 using Vintagestory.API.Common;
 
 namespace RPVoiceChat

--- a/src/Utils/EmbeddedDllLoader.cs
+++ b/src/Utils/EmbeddedDllLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;

--- a/src/Utils/Enums/VoiceLevel.cs
+++ b/src/Utils/Enums/VoiceLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace RPVoiceChat
+namespace RPVoiceChat
 {
     public enum VoiceLevel
     {

--- a/src/Utils/LocationUtils.cs
+++ b/src/Utils/LocationUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Vintagestory.API.Client;

--- a/src/Utils/Logger.cs
+++ b/src/Utils/Logger.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Client;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Server;
 

--- a/src/Utils/NetworkUtils.cs
+++ b/src/Utils/NetworkUtils.cs
@@ -1,4 +1,4 @@
-﻿using RPVoiceChat.Networking;
+using RPVoiceChat.Networking;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Utils/RecipeHandler.cs
+++ b/src/Utils/RecipeHandler.cs
@@ -1,4 +1,4 @@
-﻿using Vintagestory.API.Common;
+using Vintagestory.API.Common;
 
 namespace RPVoiceChat.Utils
 {

--- a/src/Utils/UIUtils.cs
+++ b/src/Utils/UIUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Vintagestory.API.Client;
 using Vintagestory.API.Config;
 


### PR DESCRIPTION
Adds ability for client to have multiple active connections over different transports to ensure delivery of network packets in both directions.
Adds connection retry functionality to `CustomTCP` client in case initial connection attempt failed.
Adds client-side chat notification of permanent degradation of network connection, so they can seek help or rejoin the server.
Increases amount of reconnect attempts from 1 to 5 for `CustomTCP` client.
Various improvements to stability of `CustomTCP` transport.
Improves logging
Actualizes README documentation
Bumps patch version