### PR TITLE
Various fixes and audio improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The settings relevant to users are:
 - `IsDenoisingEnabled` - Whether or not your audio should be denoised. The default value is `false`.
 - `IsHUDShown` - Whether or not the HUD should be shown. The default value is `true`.
 - `IsMuted` - Whether or not you are muted. The default value is `false`.
-- `OutputGain` - The volume level of other players in percent (0-300). The default value is `100`.
-- `InputGain` - The volume level of your microphone in percent (0-200). The default value is `100`.
+- `OutputGain` - The volume level of other players in percent (0-200). The default value is `100`.
+- `InputGain` - The volume level of your microphone in percent (0-400). The default value is `100`.
 - `InputThreshold` - The current setting of your audio input threshold in percent (0-100). The default value is `20`.
 - `BackgroungNoiseThreshold` - Sensitivity of the denoiser in percent (0-100). 0 means all audio is voice, 100 means all audio is noise. If audio is detected as noise it will be denoised at max strength. The default value is `50`.
 - `VoiceDenoisingStrength` - Intensity of voice denoising in percent (0-100). Low value won't remove noise when you are speaking, high value may decrease audio quality. The default value is `80`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can configure your microphone volume and the volume of everyone else in your
 The mod is highly configurable and can be configured more deeply in the modconfig file. You'll find this file in the `ModConfig` folder in the same directory as your `Mods` folder. The file is called `rpvoicechat.json`.
 
 The settings relevant to users are:
-- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. The default value is `false`.
+- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. **Setting this to true means that you take full responsibility for opening ports and if they are not open mod will work incorrectly.** The default value is `false`.
 - `PushToTalkEnabled` - Whether push to talk is enabled. The default value is `false`.
 - `IsLoopbackEnabled` - The setting that defines whether you should be able to hear what you're transmitting. The default value is `false`.
 - `IsDenoisingEnabled` - Whether or not your audio should be denoised. The default value is `false`.
@@ -52,7 +52,7 @@ The settings relevant to users are:
 The mod is highly configurable and can be configured more deeply in the modconfig file. You'll find this file in the `ModConfig` folder in the same directory as your `Mods` folder. The file is called `rpvoicechat.json`.
 
 The settings relevant to server owners are:
-- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. The default value is `false`.
+- `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. **Setting this to true means that you take full responsibility for opening ports and if they are not open mod will work incorrectly.** The default value is `false`.
 - `ServerPort` - The port to use for the voice networking. The default value is `52525`.
 - `ServerIP` - The ip for clients to connect to. Leave it as is unless you are playing through LAN, in which case set it to address of your private network(e.g. `"25.95.127.13"`). The default value is `null`.
 - `AdditionalContent` - Whether additional modded content(bells, horns, etc) should be enabled. The default value is `true`.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ The mod is highly configurable and can be configured more deeply in the modconfi
 
 The settings relevant to users are:
 - `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. **Setting this to true means that you take full responsibility for opening ports and if they are not open mod will work incorrectly.** The default value is `false`.
-- `PushToTalkEnabled` - Whether push to talk is enabled. The default value is `false`.
-- `IsLoopbackEnabled` - The setting that defines whether you should be able to hear what you're transmitting. The default value is `false`.
-- `IsHUDShown` - Whether or not the HUD should be shown. The default value is `true`.
-- `IsMuted` - Whether or not you are muted. The default value is `false`.
-- `InputThreshold` - The current setting of your audio input threshold in percent (0-100). The default value is `20`.
  
 ## <a name="configuration-server"></a>Configuration (For server owners)
 The mod is highly configurable and can be configured more deeply in the modconfig file. You'll find this file in the `ModConfig` folder in the same directory as your `Mods` folder. The file is called `rpvoicechat.json`.

--- a/README.md
+++ b/README.md
@@ -38,15 +38,9 @@ The settings relevant to users are:
 - `ManualPortForwarding` - Determines whether the mod should skip port forwarding with UPnP and assume that ports are open. **Setting this to true means that you take full responsibility for opening ports and if they are not open mod will work incorrectly.** The default value is `false`.
 - `PushToTalkEnabled` - Whether push to talk is enabled. The default value is `false`.
 - `IsLoopbackEnabled` - The setting that defines whether you should be able to hear what you're transmitting. The default value is `false`.
-- `IsDenoisingEnabled` - Whether or not your audio should be denoised. The default value is `false`.
 - `IsHUDShown` - Whether or not the HUD should be shown. The default value is `true`.
 - `IsMuted` - Whether or not you are muted. The default value is `false`.
-- `OutputGain` - The volume level of other players in percent (0-200). The default value is `100`.
-- `InputGain` - The volume level of your microphone in percent (0-400). The default value is `100`.
 - `InputThreshold` - The current setting of your audio input threshold in percent (0-100). The default value is `20`.
-- `BackgroungNoiseThreshold` - Sensitivity of the denoiser in percent (0-100). 0 means all audio is voice, 100 means all audio is noise. If audio is detected as noise it will be denoised at max strength. The default value is `50`.
-- `VoiceDenoisingStrength` - Intensity of voice denoising in percent (0-100). Low value won't remove noise when you are speaking, high value may decrease audio quality. The default value is `80`.
-- `MaxInputThreshold` - This configures how finely tuned the input threshold should be. The smaller number the more sensitive the input will be. The default value is `0.24`.
  
 ## <a name="configuration-server"></a>Configuration (For server owners)
 The mod is highly configurable and can be configured more deeply in the modconfig file. You'll find this file in the `ModConfig` folder in the same directory as your `Mods` folder. The file is called `rpvoicechat.json`.

--- a/assets/rpvoicechat/lang/en.json
+++ b/assets/rpvoicechat/lang/en.json
@@ -53,7 +53,7 @@
     "Gui.ModMenu.outputGain.Label": "Players Volume Level",
     "Gui.ModMenu.outputGain.Tooltip": "How much to increase volume of other players",
     "Gui.ModMenu.inputGain.Label": "Recording Volume",
-    "Gui.ModMenu.inputGain.Tooltip": "Changes your own volume. Going over 100% may clip and distort your audio, if your mic is too low increase the volume in your OS settings instead!",
+    "Gui.ModMenu.inputGain.Tooltip": "Changes your own volume",
     "Gui.ModMenu.inputThreshold.Label": "Audio Input Threshold",
     "Gui.ModMenu.inputThreshold.Tooltip": "At which threshold your audio starts transmitting",
     "Gui.ModMenu.audioMeter.Label": "Audio Meter",

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
     "description": "A mod that adds in game voice proximity chat!",
-    "version": "2.3.1"
+    "version": "2.3.2"
 }

--- a/src/Audio/Effects/Denoisers/RNNoiseDenoiser.cs
+++ b/src/Audio/Effects/Denoisers/RNNoiseDenoiser.cs
@@ -46,6 +46,7 @@ namespace RPVoiceChat.Audio.Effects
                 {
                     var remainingDataLength = rawAudio.Length - offset;
                     var denoisedAudio = new float[FRAME_SIZE];
+                    var frameLength = FRAME_SIZE;
                     using (var denoisedBuffer = new PointerSource(denoisedAudio))
                     {
                         var inPtr = pcmBuffer.ptr + offset * sizeof(float);
@@ -54,7 +55,8 @@ namespace RPVoiceChat.Audio.Effects
                         // If last frame is too small right pad it with zeros
                         if (remainingDataLength < FRAME_SIZE)
                         {
-                            Array.Copy(rawAudio, offset, denoisedAudio, 0, remainingDataLength);
+                            frameLength = remainingDataLength;
+                            Array.Copy(rawAudio, offset, denoisedAudio, 0, frameLength);
                             inPtr = outPtr;
                         }
 
@@ -64,7 +66,7 @@ namespace RPVoiceChat.Audio.Effects
                             for (var i = 0; i < denoisedAudio.Length; i++)
                                 denoisedAudio[i] = denoisedAudio[i] * strength + rawAudio[offset + i] * (1 - strength);
 
-                        denoisedAudio.CopyTo(rawAudio, offset);
+                        Array.Copy(denoisedAudio, 0, rawAudio, offset, frameLength);
                     }
                 }
             }

--- a/src/Audio/Input/MicrophoneManager.cs
+++ b/src/Audio/Input/MicrophoneManager.cs
@@ -57,7 +57,7 @@ namespace RPVoiceChat.Audio
             config = ModConfig.Config;
             MaxInputThreshold = config.MaxInputThreshold;
             SetThreshold(config.InputThreshold);
-            SetGain(config.InputGain);
+            SetGain(ClientSettings.InputGain);
             SetOutputFormat(ALFormat.Mono16);
             SetCodec(OpusCodec._Name);
             capture = CreateNewCapture(config.CurrentInputDevice);
@@ -92,9 +92,9 @@ namespace RPVoiceChat.Audio
             inputThreshold = (threshold / 100.0) * MaxInputThreshold;
         }
 
-        public void SetGain(int newGain)
+        public void SetGain(float newGain)
         {
-            gain = newGain / 100f;
+            gain = newGain;
         }
 
         public void SetDenoisingSensitivity(int sensitivity)
@@ -340,7 +340,7 @@ namespace RPVoiceChat.Audio
                 }
             }
 
-            bool guessUsedChannels = ClientSettings.GetBool("channelGuessing", true);
+            bool guessUsedChannels = ClientSettings.ChannelGuessing;
             for (var channelIndex = 0; channelIndex < InputChannelCount; channelIndex++)
             {
                 var averageSampleValue = sampleSums[channelIndex] / depth;

--- a/src/Audio/Input/MicrophoneManager.cs
+++ b/src/Audio/Input/MicrophoneManager.cs
@@ -132,7 +132,17 @@ namespace RPVoiceChat.Audio
 
             bool isMuted = config.IsMuted;
             bool isSleeping = clientEntity.AnimManager.IsAnimationActive("sleep");
-            if (isMuted || isSleeping || !clientEntity.Alive) return;
+            if (isMuted || isSleeping || !clientEntity.Alive)
+            {
+                if (recentAmplitudes.Count == 0) return;
+                recentAmplitudes.Clear();
+                Amplitude = 0;
+                Transmitting = false;
+                TransmissionStateChanged?.Invoke();
+                transmittingOnPreviousStep = Transmitting;
+                stepsSinceLastTransmission = deactivationWindow;
+                return;
+            }
 
             AudioData data = ProcessAudio(sampleBuffer);
             TransmitAudio(data);

--- a/src/Audio/Input/MicrophoneManager.cs
+++ b/src/Audio/Input/MicrophoneManager.cs
@@ -90,14 +90,14 @@ namespace RPVoiceChat.Audio
             gain = newGain;
         }
 
-        public void SetDenoisingSensitivity(int sensitivity)
+        public void SetDenoisingSensitivity(float sensitivity)
         {
-            denoiser?.SetBackgroundNoiseThreshold(sensitivity / 100f);
+            denoiser?.SetBackgroundNoiseThreshold(sensitivity);
         }
 
-        public void SetDenoisingStrength(int strength)
+        public void SetDenoisingStrength(float strength)
         {
-            denoiser?.SetVoiceDenoisingStrength(strength / 100f);
+            denoiser?.SetVoiceDenoisingStrength(strength);
         }
 
         private void CaptureAudio(object cancellationToken)
@@ -176,7 +176,7 @@ namespace RPVoiceChat.Audio
             float volumeAmplification = Math.Min(maxSafeGain, recentGainLimits.Average());
 
             // Denoise audio if applicable
-            if (config.IsDenoisingEnabled && denoiser != null && denoiser.SupportsFormat(Frequency, OutputChannelCount, SampleSize * 8))
+            if (ClientSettings.Denoising && denoiser?.SupportsFormat(Frequency, OutputChannelCount, SampleSize * 8) == true)
                 denoiser.Denoise(ref pcms);
 
             // Amplify volume and calculate amplitude
@@ -272,7 +272,7 @@ namespace RPVoiceChat.Audio
             IDenoiser denoiser = null;
             try
             {
-                denoiser = new RNNoiseDenoiser(config.BackgroungNoiseThreshold, config.VoiceDenoisingStrength);
+                denoiser = new RNNoiseDenoiser(ClientSettings.BackgroundNoiseThreshold, ClientSettings.VoiceDenoisingStrength);
                 IsDenoisingAvailable = true;
             }
             catch (DllNotFoundException)

--- a/src/Audio/Input/MicrophoneManager.cs
+++ b/src/Audio/Input/MicrophoneManager.cs
@@ -25,7 +25,7 @@ namespace RPVoiceChat.Audio
         private CancellationTokenSource audioCaptureCTS;
         private int BufferSize = (int)(Frequency * 0.5);
         private int InputChannelCount;
-        private const byte SampleSize = 2;
+        private const byte SampleSize = sizeof(short);
 
         // Audio processing
         private IAudioCodec codec;

--- a/src/Audio/Output/AudioOutputManager.cs
+++ b/src/Audio/Output/AudioOutputManager.cs
@@ -12,7 +12,6 @@ namespace RPVoiceChat.Audio
     public class AudioOutputManager : IDisposable
     {
         ICoreClientAPI capi;
-        RPVoiceChatConfig _config;
         private bool isLoopbackEnabled;
         public bool IsLoopbackEnabled
         {
@@ -41,8 +40,7 @@ namespace RPVoiceChat.Audio
 
         public AudioOutputManager(ICoreClientAPI api, ClientSettingsRepository settingsRepository)
         {
-            _config = ModConfig.Config;
-            IsLoopbackEnabled = _config.IsLoopbackEnabled;
+            IsLoopbackEnabled = ClientSettings.Loopback;
             capi = api;
             clientSettings = settingsRepository;
         }

--- a/src/Audio/Output/PlayerAudioSource.cs
+++ b/src/Audio/Output/PlayerAudioSource.cs
@@ -30,7 +30,7 @@ namespace RPVoiceChat.Audio
 
         private ICoreClientAPI capi;
         private IPlayer player;
-        private ClientSettingsRepository clientSettings;
+        private ClientSettingsRepository clientSettingsRepo;
 
         public bool IsLocational { get; set; } = true;
         public VoiceLevel voiceLevel { get; private set; } = VoiceLevel.Talking;
@@ -43,11 +43,11 @@ namespace RPVoiceChat.Audio
         private Vec3f lastSpeakerCoords;
         private DateTime? lastSpeakerUpdate;
 
-        public PlayerAudioSource(IPlayer player, ICoreClientAPI capi, ClientSettingsRepository clientSettings)
+        public PlayerAudioSource(IPlayer player, ICoreClientAPI capi, ClientSettingsRepository clientSettingsRepo)
         {
             this.player = player;
             this.capi = capi;
-            this.clientSettings = clientSettings;
+            this.clientSettingsRepo = clientSettingsRepo;
 
             lastSpeakerCoords = player.Entity?.SidedPos?.XYZFloat;
             lastSpeakerUpdate = DateTime.Now;
@@ -96,7 +96,7 @@ namespace RPVoiceChat.Audio
                 return;
 
             // If the player is on the other side of something to the listener, then the player's voice should be muffled
-            bool mufflingEnabled = ClientSettings.GetBool("muffling", true);
+            bool mufflingEnabled = ClientSettings.Muffling;
             float wallThickness = LocationUtils.GetWallThickness(capi, player, capi.World.Player);
             if (capi.World.Player.Entity.Swimming)
                 wallThickness += 1.0f;
@@ -155,7 +155,7 @@ namespace RPVoiceChat.Audio
         private float GetFinalGain()
         {
             var globalGain = Math.Min(PlayerListener.gain, 1);
-            var sourceGain = clientSettings.GetPlayerGain(player.PlayerUID);
+            var sourceGain = clientSettingsRepo.GetPlayerGain(player.PlayerUID);
             var finalGain = GameMath.Clamp(globalGain * sourceGain, 0, 1);
 
             return finalGain;

--- a/src/Audio/Output/PlayerListener.cs
+++ b/src/Audio/Output/PlayerListener.cs
@@ -11,14 +11,11 @@ namespace RPVoiceChat.Audio
         public static void Init(ICoreClientAPI api)
         {
             capi = api;
-            SetGain(ModConfig.Config.OutputGain);
-
-            ModConfig.ConfigUpdated += OnConfigUpdate;
+            SetGain(ClientSettings.OutputGain);
         }
 
         public static void SetGain(float newGain)
         {
-            newGain /= 100f;
             if (newGain == gain) return;
 
             gain = newGain;
@@ -31,16 +28,10 @@ namespace RPVoiceChat.Audio
             OALW.Listener(ALListenerf.Gain, gain);
         }
 
-        private static void OnConfigUpdate()
-        {
-            SetGain(ModConfig.Config.OutputGain);
-        }
-
         public static void Dispose()
         {
             capi = null;
             gain = 1;
-            ModConfig.ConfigUpdated -= OnConfigUpdate;
         }
     }
 }

--- a/src/Client/PlayerNetworkClient.cs
+++ b/src/Client/PlayerNetworkClient.cs
@@ -14,7 +14,7 @@ namespace RPVoiceChat.Client
 
         private ICoreClientAPI api;
         private List<INetworkClient> _initialTransports;
-        private List<INetworkClient> activeTransports;
+        private List<INetworkClient> activeTransports = new List<INetworkClient>();
         private IClientNetworkChannel handshakeChannel;
         private ConnectionInfo[] serverConnections;
         private bool isConnected = false;

--- a/src/Config/ClientSettings.cs
+++ b/src/Config/ClientSettings.cs
@@ -7,12 +7,18 @@ namespace RPVoiceChat
     {
         public static float OutputGain { get => GetFloat("outputGain", 1); set => Set("outputGain", value); }
         public static float InputGain { get => GetFloat("inputGain", 1); set => Set("inputGain", value); }
+        public static float InputThreshold { get => GetFloat("inputThreshold", 0.2f); set => Set("inputThreshold", value); }
         public static float BackgroundNoiseThreshold { get => GetFloat("denoisingSensitivity", 0.5f); set => Set("denoisingSensitivity", value); }
         public static float VoiceDenoisingStrength { get => GetFloat("denoisingStrength", 0.1f); set => Set("denoisingStrength", value); }
+        public static bool PushToTalkEnabled { get => GetBool("ptt", false); set => Set("ptt", value); }
+        public static bool IsMuted { get => GetBool("muteMic", false); set => Set("muteMic", value); }
+        public static bool Loopback { get => GetBool("loopback", false); set => Set("loopback", value); }
+        public static bool ShowHud { get => GetBool("showHud", true); set => Set("showHud", value); }
         public static bool Muffling { get => GetBool("muffling", true); set => Set("muffling", value); }
         public static bool Denoising { get => GetBool("denoising", false); set => Set("denoising", value); }
         public static bool ChannelGuessing { get => GetBool("channelGuessing", true); set => Set("channelGuessing", value); }
         public static int ActiveConfigTab { get => GetInt("activeConfigTab", 0); set => Set("activeConfigTab", value); }
+        public static string CurrentInputDevice { get => GetStr("inputDevice"); set => Set("inputDevice", value); }
 
         private const string modPrefix = "RPVoiceChat";
         private static ICoreClientAPI capi;

--- a/src/Config/ClientSettings.cs
+++ b/src/Config/ClientSettings.cs
@@ -4,6 +4,12 @@ namespace RPVoiceChat
 {
     public static class ClientSettings
     {
+        public static float OutputGain { get => GetFloat("outputGain", 1); set => Set("outputGain", value); }
+        public static float InputGain { get => GetFloat("inputGain", 1); set => Set("inputGain", value); }
+        public static bool Muffling { get => GetBool("muffling", true); set => Set("muffling", value); }
+        public static bool ChannelGuessing { get => GetBool("channelGuessing", true); set => Set("channelGuessing", value); }
+        public static int ActiveConfigTab { get => GetInt("activeConfigTab", 0); set => Set("activeConfigTab", value); }
+
         private const string modPrefix = "RPVoiceChat";
         private static ICoreClientAPI capi;
 

--- a/src/Config/ClientSettings.cs
+++ b/src/Config/ClientSettings.cs
@@ -6,7 +6,10 @@ namespace RPVoiceChat
     {
         public static float OutputGain { get => GetFloat("outputGain", 1); set => Set("outputGain", value); }
         public static float InputGain { get => GetFloat("inputGain", 1); set => Set("inputGain", value); }
+        public static float BackgroundNoiseThreshold { get => GetFloat("denoisingSensitivity", 0.5f); set => Set("denoisingSensitivity", value); }
+        public static float VoiceDenoisingStrength { get => GetFloat("denoisingStrength", 0.1f); set => Set("denoisingStrength", value); }
         public static bool Muffling { get => GetBool("muffling", true); set => Set("muffling", value); }
+        public static bool Denoising { get => GetBool("denoising", false); set => Set("denoising", value); }
         public static bool ChannelGuessing { get => GetBool("channelGuessing", true); set => Set("channelGuessing", value); }
         public static int ActiveConfigTab { get => GetInt("activeConfigTab", 0); set => Set("activeConfigTab", value); }
 

--- a/src/Config/ClientSettings.cs
+++ b/src/Config/ClientSettings.cs
@@ -1,4 +1,5 @@
 using Vintagestory.API.Client;
+using Vintagestory.API.Common;
 
 namespace RPVoiceChat
 {
@@ -16,9 +17,10 @@ namespace RPVoiceChat
         private const string modPrefix = "RPVoiceChat";
         private static ICoreClientAPI capi;
 
-        public static void Init(ICoreClientAPI api)
+        public static void Init(ICoreAPI api)
         {
-            capi = api;
+            if (api is ICoreClientAPI capi)
+                ClientSettings.capi = capi;
         }
 
         public static void Set(string key, int value)

--- a/src/Config/ModConfig.cs
+++ b/src/Config/ModConfig.cs
@@ -21,6 +21,7 @@ namespace RPVoiceChat
                 else
                 {
                     GenerateConfig(api, Config);
+                    Config = LoadConfig(api);
                 }
             }
             catch
@@ -37,6 +38,6 @@ namespace RPVoiceChat
 
         private static RPVoiceChatConfig LoadConfig(ICoreAPI api) => api.LoadModConfig<RPVoiceChatConfig>(ConfigFileName);
         private static void GenerateConfig(ICoreAPI api) => api.StoreModConfig(new RPVoiceChatConfig(), ConfigFileName);
-        private static void GenerateConfig(ICoreAPI api, RPVoiceChatConfig previousConfig) => api.StoreModConfig(new RPVoiceChatConfig(previousConfig), ConfigFileName);
+        private static void GenerateConfig(ICoreAPI api, RPVoiceChatConfig previousConfig) => api.StoreModConfig(new RPVoiceChatConfig(api.Side, previousConfig), ConfigFileName);
     }
 }

--- a/src/Config/ModConfig.cs
+++ b/src/Config/ModConfig.cs
@@ -1,4 +1,3 @@
-using System;
 using Vintagestory.API.Common;
 
 namespace RPVoiceChat
@@ -7,7 +6,6 @@ namespace RPVoiceChat
     {
         private const string ConfigFileName = "rpvoicechat.json";
         public static RPVoiceChatConfig Config { get; private set; }
-        public static event Action ConfigUpdated;
 
         public static void ReadConfig(ICoreAPI api)
         {
@@ -35,7 +33,6 @@ namespace RPVoiceChat
         public static void Save(ICoreAPI api)
         {
             GenerateConfig(api, Config);
-            ConfigUpdated?.Invoke();
         }
 
         private static RPVoiceChatConfig LoadConfig(ICoreAPI api) => api.LoadModConfig<RPVoiceChatConfig>(ConfigFileName);

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -28,10 +28,7 @@ namespace RPVoiceChat
         public int VoiceDenoisingStrength = 80;
         public string CurrentInputDevice;
 
-        public RPVoiceChatConfig()
-        {
-
-        }
+        public RPVoiceChatConfig() { }
 
         public RPVoiceChatConfig(RPVoiceChatConfig previousConfig)
         {
@@ -51,6 +48,5 @@ namespace RPVoiceChat
             BackgroungNoiseThreshold = previousConfig.BackgroungNoiseThreshold;
             VoiceDenoisingStrength = previousConfig.VoiceDenoisingStrength;
         }
-
     }
 }

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -27,7 +27,6 @@ namespace RPVoiceChat
         public int BackgroungNoiseThreshold = 50;
         public int VoiceDenoisingStrength = 80;
         public string CurrentInputDevice;
-        public double MaxInputThreshold = 0.24;
 
         public RPVoiceChatConfig()
         {
@@ -51,7 +50,6 @@ namespace RPVoiceChat
             CurrentInputDevice = previousConfig.CurrentInputDevice;
             BackgroungNoiseThreshold = previousConfig.BackgroungNoiseThreshold;
             VoiceDenoisingStrength = previousConfig.VoiceDenoisingStrength;
-            MaxInputThreshold = previousConfig.MaxInputThreshold;
         }
 
     }

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -1,7 +1,12 @@
+using System;
+using Vintagestory.API.Common;
+
 namespace RPVoiceChat
 {
     public class RPVoiceChatConfig
     {
+        private const string _version = "v1";
+        public string Version;
 
         // --- Shared Config ---
         // These are meant to be set by anyone and
@@ -27,8 +32,9 @@ namespace RPVoiceChat
 
         public RPVoiceChatConfig() { }
 
-        public RPVoiceChatConfig(RPVoiceChatConfig previousConfig)
+        public RPVoiceChatConfig(EnumAppSide side, RPVoiceChatConfig previousConfig)
         {
+            Version = previousConfig.Version;
             ManualPortForwarding = previousConfig.ManualPortForwarding;
 
             ServerPort = previousConfig.ServerPort;
@@ -41,6 +47,14 @@ namespace RPVoiceChat
             IsMuted = previousConfig.IsMuted;
             InputThreshold = previousConfig.InputThreshold;
             CurrentInputDevice = previousConfig.CurrentInputDevice;
+
+            if (Version != _version)
+                UpdateConfigVersion(side);
+        }
+
+        public void UpdateConfigVersion(EnumAppSide side)
+        {
+            Version = _version;
         }
     }
 }

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -23,8 +23,6 @@ namespace RPVoiceChat
         public bool IsDenoisingEnabled = false;
         public bool IsHUDShown = true;
         public bool IsMuted = false;
-        public int OutputGain = 100;
-        public int InputGain = 100;
         public int InputThreshold = 20;
         public int BackgroungNoiseThreshold = 50;
         public int VoiceDenoisingStrength = 80;
@@ -49,8 +47,6 @@ namespace RPVoiceChat
             IsDenoisingEnabled = previousConfig.IsDenoisingEnabled;
             IsHUDShown = previousConfig.IsHUDShown;
             IsMuted = previousConfig.IsMuted;
-            OutputGain = previousConfig.OutputGain;
-            InputGain = previousConfig.InputGain;
             InputThreshold = previousConfig.InputThreshold;
             CurrentInputDevice = previousConfig.CurrentInputDevice;
             BackgroungNoiseThreshold = previousConfig.BackgroungNoiseThreshold;

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -23,15 +23,18 @@ namespace RPVoiceChat
         // --- Client Settings ---
         // These are meant to be set by the client, but are
         // stored here for persistence across sessions
+        [Obsolete("This setting was moved into ClientSettings and only kept here for backwards compatibility. It will soon be removed.")]
         public bool PushToTalkEnabled = false;
-        public bool IsLoopbackEnabled = false;
-        public bool IsHUDShown = true;
+        [Obsolete("This setting was moved into ClientSettings and only kept here for backwards compatibility. It will soon be removed.")]
         public bool IsMuted = false;
+        [Obsolete("This setting was moved into ClientSettings and only kept here for backwards compatibility. It will soon be removed.")]
         public int InputThreshold = 20;
+        [Obsolete("This setting was moved into ClientSettings and only kept here for backwards compatibility. It will soon be removed.")]
         public string CurrentInputDevice;
 
         public RPVoiceChatConfig() { }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public RPVoiceChatConfig(EnumAppSide side, RPVoiceChatConfig previousConfig)
         {
             Version = previousConfig.Version;
@@ -42,8 +45,6 @@ namespace RPVoiceChat
             AdditionalContent = previousConfig.AdditionalContent;
 
             PushToTalkEnabled = previousConfig.PushToTalkEnabled;
-            IsLoopbackEnabled = previousConfig.IsLoopbackEnabled;
-            IsHUDShown = previousConfig.IsHUDShown;
             IsMuted = previousConfig.IsMuted;
             InputThreshold = previousConfig.InputThreshold;
             CurrentInputDevice = previousConfig.CurrentInputDevice;
@@ -54,7 +55,13 @@ namespace RPVoiceChat
 
         public void UpdateConfigVersion(EnumAppSide side)
         {
+            if (side == EnumAppSide.Server) return;
+            ClientSettings.PushToTalkEnabled = PushToTalkEnabled;
+            ClientSettings.IsMuted = IsMuted;
+            ClientSettings.InputThreshold = (float)InputThreshold / 100;
+            ClientSettings.CurrentInputDevice = CurrentInputDevice;
             Version = _version;
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -20,12 +20,9 @@ namespace RPVoiceChat
         // stored here for persistence across sessions
         public bool PushToTalkEnabled = false;
         public bool IsLoopbackEnabled = false;
-        public bool IsDenoisingEnabled = false;
         public bool IsHUDShown = true;
         public bool IsMuted = false;
         public int InputThreshold = 20;
-        public int BackgroungNoiseThreshold = 50;
-        public int VoiceDenoisingStrength = 80;
         public string CurrentInputDevice;
 
         public RPVoiceChatConfig() { }
@@ -40,13 +37,10 @@ namespace RPVoiceChat
 
             PushToTalkEnabled = previousConfig.PushToTalkEnabled;
             IsLoopbackEnabled = previousConfig.IsLoopbackEnabled;
-            IsDenoisingEnabled = previousConfig.IsDenoisingEnabled;
             IsHUDShown = previousConfig.IsHUDShown;
             IsMuted = previousConfig.IsMuted;
             InputThreshold = previousConfig.InputThreshold;
             CurrentInputDevice = previousConfig.CurrentInputDevice;
-            BackgroungNoiseThreshold = previousConfig.BackgroungNoiseThreshold;
-            VoiceDenoisingStrength = previousConfig.VoiceDenoisingStrength;
         }
     }
 }

--- a/src/Config/WorldConfig.cs
+++ b/src/Config/WorldConfig.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.Server;
 
 namespace RPVoiceChat
 {
@@ -16,6 +18,7 @@ namespace RPVoiceChat
 
         public static void Init(ICoreAPI api)
         {
+            if (api is ICoreClientAPI && WorldConfig.api is ICoreServerAPI) return;
             WorldConfig.api = api;
         }
 

--- a/src/Gui/CustomElements/AudioMeter.cs
+++ b/src/Gui/CustomElements/AudioMeter.cs
@@ -13,7 +13,6 @@ namespace RPVoiceChat.Gui
         private string key;
         private long gameTickListenerId;
         private double coefficient;
-        private double threshold;
 
         public AudioMeter(ICoreClientAPI capi, MicrophoneManager audioInputManager, GuiDialog parrent, bool unscaled = false) : base(capi, null, new double[3] { 0.1, 0.4, 0.1 }, false, true)
         {
@@ -55,26 +54,17 @@ namespace RPVoiceChat.Gui
             var element = parrentDialog.SingleComposer.GetElement(key);
             if (element == null) return;
 
-            SetThreshold(_audioInputManager.GetInputThreshold());
-            var amplitude = Math.Max(_audioInputManager.Amplitude, _audioInputManager.AmplitudeAverage);
+            double amplitude = _audioInputManager.Amplitude;
             if (ModConfig.Config.IsMuted) amplitude = 0;
             UpdateVisuals(amplitude);
         }
 
-        private void SetThreshold(double threshold)
-        {
-            this.threshold = threshold;
-        }
-
         private void UpdateVisuals(double amplitude)
         {
-            if (amplitude <= 0) amplitude = 0;
+            float displayValue = (float)Math.Round(amplitude * coefficient);
 
-            ShouldFlash = amplitude > threshold;
-            amplitude = amplitude * coefficient;
-            amplitude = Math.Round(amplitude);
-
-            SetValue((float)amplitude);
+            ShouldFlash = _audioInputManager.Transmitting;
+            SetValue(displayValue);
         }
     }
 }

--- a/src/Gui/CustomElements/AudioMeter.cs
+++ b/src/Gui/CustomElements/AudioMeter.cs
@@ -54,14 +54,12 @@ namespace RPVoiceChat.Gui
             var element = parrentDialog.SingleComposer.GetElement(key);
             if (element == null) return;
 
-            double amplitude = _audioInputManager.Amplitude;
-            if (ModConfig.Config.IsMuted) amplitude = 0;
-            UpdateVisuals(amplitude);
+            UpdateVisuals();
         }
 
-        private void UpdateVisuals(double amplitude)
+        private void UpdateVisuals()
         {
-            float displayValue = (float)Math.Round(amplitude * coefficient);
+            float displayValue = (float)Math.Round(_audioInputManager.Amplitude * coefficient);
 
             ShouldFlash = _audioInputManager.Transmitting;
             SetValue(displayValue);

--- a/src/Gui/CustomElements/AudioMeter.cs
+++ b/src/Gui/CustomElements/AudioMeter.cs
@@ -24,7 +24,6 @@ namespace RPVoiceChat.Gui
 
             parrentDialog.OnOpened += OnDialogOpen;
             parrentDialog.OnClosed += OnDialogClosed;
-            ModConfig.ConfigUpdated += OnConfigUpdate;
         }
 
         public void Init(string elementKey, ElementBounds bounds, GuiComposer composer)
@@ -48,11 +47,6 @@ namespace RPVoiceChat.Gui
         private void OnDialogClosed()
         {
             api.Event.UnregisterGameTickListener(gameTickListenerId);
-        }
-
-        private void OnConfigUpdate()
-        {
-            SetCoefficient();
         }
 
         private void TickUpdate(float _)

--- a/src/Gui/Hud/SpeechIndicator.cs
+++ b/src/Gui/Hud/SpeechIndicator.cs
@@ -7,10 +7,10 @@ namespace RPVoiceChat.Gui
 {
     public class SpeechIndicator : HudElement
     {
-        RPVoiceChatConfig _config;
-        const float size = 64;
-        const int silenceTimeout = 160;
-        ElementBounds dialogBounds = new ElementBounds()
+        private const float size = 64;
+        private RPVoiceChatConfig config;
+        private MicrophoneManager audioInputManager;
+        private ElementBounds dialogBounds = new ElementBounds()
         {
             Alignment = EnumDialogArea.RightBottom,
             BothSizing = ElementSizing.Fixed,
@@ -19,59 +19,32 @@ namespace RPVoiceChat.Gui
             fixedPaddingX = 10,
             fixedPaddingY = 10
         };
-
-        string voice;
-        bool isTalking;
-        long? silenceTimer;
+        private string voiceType;
 
         public SpeechIndicator(ICoreClientAPI capi, MicrophoneManager microphoneManager) : base(capi)
         {
-            _config = ModConfig.Config;
+            config = ModConfig.Config;
+            audioInputManager = microphoneManager;
 
-            GuiDialogCreateCharacterPatch.OnCharacterSelection += bindToMainThread(UpdateVoice);
-            microphoneManager.ClientStartTalking += bindToMainThread(OnClientStartTalking);
-            microphoneManager.ClientStopTalking += bindToMainThread(OnClientStopTalking);
+            GuiDialogCreateCharacterPatch.OnCharacterSelection += bindToMainThread(UpdateVoiceType);
+            microphoneManager.TransmissionStateChanged += bindToMainThread(UpdateDisplay);
             ModConfig.ConfigUpdated += bindToMainThread(OnConfigUpdate);
         }
 
         public override void OnOwnPlayerDataReceived()
         {
-            UpdateVoice();
+            UpdateVoiceType();
         }
 
-        public void UpdateVoice()
+        private void UpdateVoiceType()
         {
-            voice = capi.World.Player?.Entity.talkUtil.soundName.GetName() ?? voice;
+            voiceType = capi.World.Player?.Entity.talkUtil.soundName.GetName() ?? voiceType;
             SetupIcon();
         }
 
         private Action bindToMainThread(Action function)
         {
             return () => { capi.Event.EnqueueMainThreadTask(function, "rpvoicechat:SpeechIndicator"); };
-        }
-
-        private void OnClientStartTalking()
-        {
-            if (silenceTimer != null)
-            {
-                capi.Event.UnregisterCallback((long)silenceTimer);
-                silenceTimer = null;
-            }
-            isTalking = true;
-            UpdateDisplay();
-        }
-
-        private void OnClientStopTalking()
-        {
-            if (silenceTimer != null) return;
-            silenceTimer = capi.Event.RegisterCallback(OnSilence, silenceTimeout);
-        }
-
-        private void OnSilence(float _)
-        {
-            silenceTimer = null;
-            isTalking = false;
-            UpdateDisplay();
         }
 
         private void OnConfigUpdate()
@@ -81,7 +54,8 @@ namespace RPVoiceChat.Gui
 
         private void UpdateDisplay()
         {
-            bool shouldDisplay = (_config.IsMuted || isTalking) && _config.IsHUDShown;
+            bool isTalking = audioInputManager.Transmitting;
+            bool shouldDisplay = (config.IsMuted || isTalking) && config.IsHUDShown;
             bool successful = shouldDisplay ? TryOpen() : TryClose();
 
             if (!successful) bindToMainThread(UpdateDisplay)();
@@ -90,19 +64,13 @@ namespace RPVoiceChat.Gui
         public void SetupIcon()
         {
             SingleComposer = capi.Gui.CreateCompo("rpvcspeechindicator", dialogBounds)
-                .AddImage(ElementBounds.Fixed(0, 0, size, size), new AssetLocation("rpvoicechat", "textures/gui/" + voice + ".png"))
-                .AddIf(_config.IsMuted)
+                .AddImage(ElementBounds.Fixed(0, 0, size, size), new AssetLocation("rpvoicechat", "textures/gui/" + voiceType + ".png"))
+                .AddIf(config.IsMuted)
                 .AddImage(ElementBounds.Fixed(0, 0, size, size), new AssetLocation("rpvoicechat", "textures/gui/muted.png"))
                 .EndIf()
                 .Compose();
 
             UpdateDisplay();
-        }
-
-        public override void Dispose()
-        {
-            if (silenceTimer == null) return;
-            capi.Event.UnregisterCallback((long)silenceTimer);
         }
     }
 }

--- a/src/Gui/Hud/SpeechIndicator.cs
+++ b/src/Gui/Hud/SpeechIndicator.cs
@@ -8,7 +8,6 @@ namespace RPVoiceChat.Gui
     public class SpeechIndicator : HudElement
     {
         private const float size = 64;
-        private RPVoiceChatConfig config;
         private MicrophoneManager audioInputManager;
         private ElementBounds dialogBounds = new ElementBounds()
         {
@@ -23,7 +22,6 @@ namespace RPVoiceChat.Gui
 
         public SpeechIndicator(ICoreClientAPI capi, MicrophoneManager microphoneManager) : base(capi)
         {
-            config = ModConfig.Config;
             audioInputManager = microphoneManager;
 
             GuiDialogCreateCharacterPatch.OnCharacterSelection += bindToMainThread(UpdateVoiceType);
@@ -55,7 +53,7 @@ namespace RPVoiceChat.Gui
         private void UpdateDisplay()
         {
             bool isTalking = audioInputManager.Transmitting;
-            bool shouldDisplay = (config.IsMuted || isTalking) && config.IsHUDShown;
+            bool shouldDisplay = (ClientSettings.IsMuted || isTalking) && ClientSettings.ShowHud;
             bool successful = shouldDisplay ? TryOpen() : TryClose();
 
             if (!successful) bindToMainThread(UpdateDisplay)();
@@ -65,7 +63,7 @@ namespace RPVoiceChat.Gui
         {
             SingleComposer = capi.Gui.CreateCompo("rpvcspeechindicator", dialogBounds)
                 .AddImage(ElementBounds.Fixed(0, 0, size, size), new AssetLocation("rpvoicechat", "textures/gui/" + voiceType + ".png"))
-                .AddIf(config.IsMuted)
+                .AddIf(ClientSettings.IsMuted)
                 .AddImage(ElementBounds.Fixed(0, 0, size, size), new AssetLocation("rpvoicechat", "textures/gui/muted.png"))
                 .EndIf()
                 .Compose();

--- a/src/Gui/Hud/SpeechIndicator.cs
+++ b/src/Gui/Hud/SpeechIndicator.cs
@@ -28,7 +28,7 @@ namespace RPVoiceChat.Gui
 
             GuiDialogCreateCharacterPatch.OnCharacterSelection += bindToMainThread(UpdateVoiceType);
             microphoneManager.TransmissionStateChanged += bindToMainThread(UpdateDisplay);
-            ModConfig.ConfigUpdated += bindToMainThread(OnConfigUpdate);
+            capi.Event.RegisterEventBusListener(OnHudUpdate, 0.5, "rpvoicechat:hudUpdate");
         }
 
         public override void OnOwnPlayerDataReceived()
@@ -47,9 +47,9 @@ namespace RPVoiceChat.Gui
             return () => { capi.Event.EnqueueMainThreadTask(function, "rpvoicechat:SpeechIndicator"); };
         }
 
-        private void OnConfigUpdate()
+        private void OnHudUpdate(string _, ref EnumHandling __, object ___)
         {
-            SetupIcon();
+            bindToMainThread(SetupIcon)();
         }
 
         private void UpdateDisplay()

--- a/src/Gui/Hud/VoiceLevelIcon.cs
+++ b/src/Gui/Hud/VoiceLevelIcon.cs
@@ -32,7 +32,7 @@ namespace RPVoiceChat.Gui
             currentVoiceLevel = microphoneManager.GetVoiceLevel();
 
             microphoneManager.VoiceLevelUpdated += OnVoiceLevelUpdated;
-            ModConfig.ConfigUpdated += bindToMainThread(OnConfigUpdate);
+            capi.Event.RegisterEventBusListener(OnHudUpdate, 0.5, "rpvoicechat:hudUpdate");
         }
 
         public override void OnOwnPlayerDataReceived()
@@ -51,9 +51,9 @@ namespace RPVoiceChat.Gui
             bindToMainThread(SetupIcon)();
         }
 
-        private void OnConfigUpdate()
+        private void OnHudUpdate(string _, ref EnumHandling __, object ___)
         {
-            SetupIcon();
+            bindToMainThread(SetupIcon)();
         }
 
         private void UpdateDisplay()

--- a/src/Gui/Hud/VoiceLevelIcon.cs
+++ b/src/Gui/Hud/VoiceLevelIcon.cs
@@ -58,7 +58,7 @@ namespace RPVoiceChat.Gui
 
         private void UpdateDisplay()
         {
-            bool shouldDisplay = ModConfig.Config.IsHUDShown;
+            bool shouldDisplay = ClientSettings.ShowHud;
             bool successful = shouldDisplay ? TryOpen() : TryClose();
 
             if (!successful) bindToMainThread(UpdateDisplay)();

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -433,6 +433,7 @@ namespace RPVoiceChat.Gui
         {
             _config.IsMuted = enabled;
             ModConfig.Save(capi);
+            capi.Event.PushEvent("rpvoicechat:hudUpdate");
         }
 
         protected void OnToggleLoopback(bool enabled)
@@ -490,6 +491,7 @@ namespace RPVoiceChat.Gui
         {
             _config.IsHUDShown = enabled;
             ModConfig.Save(capi);
+            capi.Event.PushEvent("rpvoicechat:hudUpdate");
         }
 
         private void OnToggleMuffling(bool enabled)

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -23,7 +23,7 @@ namespace RPVoiceChat.Gui
         private const double sliderWidth = 200.0;
         private const int tooltipWidth = 260;
         private const int _tabTextPadding = 4;
-        private bool _isSetup;
+        private bool isSetup;
         private List<ConfigOption> ConfigOptions = new List<ConfigOption>();
         private List<ConfigTab> ConfigTabs = new List<ConfigTab>();
 
@@ -94,7 +94,7 @@ namespace RPVoiceChat.Gui
 
         protected void SetupDialog()
         {
-            _isSetup = true;
+            isSetup = true;
 
             var activeTab = ConfigTabs[ClientSettings.ActiveConfigTab];
             var displayedOptions = ConfigOptions.FindAll(e => e.Tab == activeTab && e.Enabled);
@@ -125,8 +125,7 @@ namespace RPVoiceChat.Gui
                 {
                     case ElementType.Slider:
                         var slider = new GuiElementSlider(capi, option.SlideAction, wideSettingBounds);
-                        if (option.SlideTooltip != null)
-                            slider.OnSliderTooltip = option.SlideTooltip;
+                        if (option.SlideTooltip != null) slider.OnSliderTooltip = option.SlideTooltip;
                         composer.AddInteractiveElement(slider, option.Key);
                         break;
 
@@ -166,7 +165,7 @@ namespace RPVoiceChat.Gui
 
         public override bool TryOpen()
         {
-            if (!_isSetup)
+            if (!isSetup)
                 SetupDialog();
 
             var success = base.TryOpen();
@@ -196,15 +195,13 @@ namespace RPVoiceChat.Gui
 
     public class ModMenuDialog : ConfigDialog
     {
-        private RPVoiceChatConfig _config;
-        private MicrophoneManager _audioInputManager;
-        private AudioOutputManager _audioOutputManager;
+        private MicrophoneManager audioInputManager;
+        private AudioOutputManager audioOutputManager;
 
-        public ModMenuDialog(ICoreClientAPI capi, MicrophoneManager audioInputManager, AudioOutputManager audioOutputManager, ClientSettingsRepository settingsRepository) : base(capi)
+        public ModMenuDialog(ICoreClientAPI capi, MicrophoneManager _audioInputManager, AudioOutputManager _audioOutputManager, ClientSettingsRepository settingsRepository) : base(capi)
         {
-            _config = ModConfig.Config;
-            _audioInputManager = audioInputManager;
-            _audioOutputManager = audioOutputManager;
+            audioInputManager = _audioInputManager;
+            audioOutputManager = _audioOutputManager;
 
             var audioInputTab = new ConfigTab("AudioInput");
             var audioOutputTab = new ConfigTab("AudioOutput");
@@ -226,8 +223,8 @@ namespace RPVoiceChat.Gui
                 Label = true,
                 Tooltip = true,
                 Tab = audioInputTab,
-                DropdownNames = _audioInputManager.GetInputDeviceNames(),
-                DropdownValues = _audioInputManager.GetInputDeviceNames(),
+                DropdownNames = audioInputManager.GetInputDeviceNames(),
+                DropdownValues = audioInputManager.GetInputDeviceNames(),
                 DropdownSelect = OnChangeInputDevice
             });
 
@@ -299,7 +296,7 @@ namespace RPVoiceChat.Gui
                 Label = true,
                 Tooltip = true,
                 Tab = audioInputTab,
-                CustomElement = new AudioMeter(capi, _audioInputManager, this)
+                CustomElement = new AudioMeter(capi, audioInputManager, this)
             });
 
             RegisterOption(new ConfigOption
@@ -421,7 +418,7 @@ namespace RPVoiceChat.Gui
 
         private void OnChangeInputDevice(string value, bool selected)
         {
-            _audioInputManager.SetInputDevice(value);
+            audioInputManager.SetInputDevice(value);
         }
 
         private void OnTogglePushToTalk(bool enabled)
@@ -438,7 +435,7 @@ namespace RPVoiceChat.Gui
         protected void OnToggleLoopback(bool enabled)
         {
             ClientSettings.Loopback = enabled;
-            _audioOutputManager.IsLoopbackEnabled = enabled;
+            audioOutputManager.IsLoopbackEnabled = enabled;
         }
 
         private bool SlideOutputGain(int intGain)
@@ -456,7 +453,7 @@ namespace RPVoiceChat.Gui
             float gain = AudioUtils.DBsToFactor(dBGain);
             if (intDBGain == -200) gain = 0;
             ClientSettings.InputGain = gain;
-            _audioInputManager.SetGain(gain);
+            audioInputManager.SetGain(gain);
 
             return true;
         }
@@ -480,7 +477,7 @@ namespace RPVoiceChat.Gui
         {
             float threshold = (float)intThreshold / 100;
             ClientSettings.InputThreshold = threshold;
-            _audioInputManager.SetThreshold(threshold);
+            audioInputManager.SetThreshold(threshold);
 
             return true;
         }
@@ -505,7 +502,7 @@ namespace RPVoiceChat.Gui
         {
             float sensitivity = (float)intSensitivity / 100;
             ClientSettings.BackgroundNoiseThreshold = sensitivity;
-            _audioInputManager.SetDenoisingSensitivity(sensitivity);
+            audioInputManager.SetDenoisingSensitivity(sensitivity);
 
             return true;
         }
@@ -514,7 +511,7 @@ namespace RPVoiceChat.Gui
         {
             float strength = (float)intStrength / 100;
             ClientSettings.VoiceDenoisingStrength = strength;
-            _audioInputManager.SetDenoisingStrength(strength);
+            audioInputManager.SetDenoisingStrength(strength);
 
             return true;
         }

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
 
 namespace RPVoiceChat.Gui
 {
@@ -399,7 +400,7 @@ namespace RPVoiceChat.Gui
             SetValue("togglePushToTalk", _config.PushToTalkEnabled);
             SetValue("muteMicrophone", _config.IsMuted);
             SetValue("loopback", _config.IsLoopbackEnabled);
-            SetValue("outputGain", new dynamic[] { _config.OutputGain, 0, 300, 1, "%" });
+            SetValue("outputGain", new dynamic[] { _config.OutputGain, 0, 200, 1, "%" });
             SetValue("inputGain", new dynamic[] { _config.InputGain, 0, 400, 1, "%" });
             SetValue("inputThreshold", new dynamic[] { _config.InputThreshold, 0, 100, 1, "" });
             SetValue("toggleHUD", _config.IsHUDShown);
@@ -420,7 +421,8 @@ namespace RPVoiceChat.Gui
             else if (element is GuiElementSwitch switchBox) switchBox.On = value;
             else if (element is GuiElementSlider slider)
             {
-                slider.SetValues(value[0], value[1], value[2], value[3], value[4]);
+                int sliderValue = GameMath.Clamp(value[0], value[1], value[2]);
+                slider.SetValues(sliderValue, value[1], value[2], value[3], value[4]);
                 if (value.Length < 6) return;
                 slider.SetAlarmValue(value[5]);
             }

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -367,26 +367,6 @@ namespace RPVoiceChat.Gui
                 Tab = advancedTab,
                 ToggleAction = OnToggleChannelGuessing
             });
-
-            RegisterOption(new ConfigOption
-            {
-                Key = "inputSensitivity",
-                Type = ElementType.Slider,
-                Label = true,
-                Tooltip = true,
-                Tab = advancedTab,
-                SlideAction = SlideInputSensitivity
-            });
-
-            RegisterOption(new ConfigOption
-            {
-                Key = "unscaledAudioMeter",
-                Type = ElementType.Custom,
-                Label = true,
-                Tooltip = true,
-                Tab = advancedTab,
-                CustomElement = new AudioMeter(capi, _audioInputManager, this, true)
-            });
         }
 
         protected override void RefreshValues()
@@ -411,7 +391,6 @@ namespace RPVoiceChat.Gui
             SetValue("denoisingStrength", new dynamic[] { _config.VoiceDenoisingStrength, 0, 100, 1, "%" });
             SetValue("playerList", null);
             SetValue("toggleChannelGuessing", ClientSettings.ChannelGuessing);
-            SetValue("inputSensitivity", new dynamic[] { (int)(_config.MaxInputThreshold * 100), 1, 100, 1, "%" });
         }
 
         private void SetValue(string key, dynamic value)
@@ -521,15 +500,6 @@ namespace RPVoiceChat.Gui
         private void OnToggleChannelGuessing(bool enabled)
         {
             ClientSettings.ChannelGuessing = enabled;
-        }
-
-        private bool SlideInputSensitivity(int sensitivity)
-        {
-            _audioInputManager.SetMaxInputThreshold(sensitivity);
-            _config.MaxInputThreshold = _audioInputManager.GetMaxInputThreshold();
-            ModConfig.Save(capi);
-
-            return true;
         }
     }
 }

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -381,6 +381,8 @@ namespace RPVoiceChat.Gui
 
             var outputGain = ClientSettings.OutputGain * 100;
             var inputGainDBS = AudioUtils.FactorToDBs(ClientSettings.InputGain) * 10;
+            var denoisingSensitivity = ClientSettings.BackgroundNoiseThreshold * 100;
+            var denoisingStrength = ClientSettings.VoiceDenoisingStrength * 100;
             SetValue("configTabs", ClientSettings.ActiveConfigTab);
             SetValue("inputDevice", _config.CurrentInputDevice ?? "Default");
             SetValue("togglePushToTalk", _config.PushToTalkEnabled);
@@ -391,9 +393,9 @@ namespace RPVoiceChat.Gui
             SetValue("inputThreshold", new dynamic[] { _config.InputThreshold, 0, 100, 1, "" });
             SetValue("toggleHUD", _config.IsHUDShown);
             SetValue("toggleMuffling", ClientSettings.Muffling);
-            SetValue("toggleDenoising", _config.IsDenoisingEnabled);
-            SetValue("denoisingSensitivity", new dynamic[] { _config.BackgroungNoiseThreshold, 0, 100, 1, "%" });
-            SetValue("denoisingStrength", new dynamic[] { _config.VoiceDenoisingStrength, 0, 100, 1, "%" });
+            SetValue("toggleDenoising", ClientSettings.Denoising);
+            SetValue("denoisingSensitivity", new dynamic[] { denoisingSensitivity, 0, 100, 1, "%" });
+            SetValue("denoisingStrength", new dynamic[] { denoisingStrength, 0, 100, 1, "%" });
             SetValue("playerList", null);
             SetValue("toggleChannelGuessing", ClientSettings.ChannelGuessing);
         }
@@ -497,24 +499,23 @@ namespace RPVoiceChat.Gui
 
         private void OnToggleDenoising(bool enabled)
         {
-            _config.IsDenoisingEnabled = enabled;
-            ModConfig.Save(capi);
+            ClientSettings.Denoising = enabled;
         }
 
-        private bool SlideDenoisingSensitivity(int sensitivity)
+        private bool SlideDenoisingSensitivity(int intSensitivity)
         {
-            _config.BackgroungNoiseThreshold = sensitivity;
+            float sensitivity = (float)intSensitivity / 100;
+            ClientSettings.BackgroundNoiseThreshold = sensitivity;
             _audioInputManager.SetDenoisingSensitivity(sensitivity);
-            ModConfig.Save(capi);
 
             return true;
         }
 
-        private bool SlideDenoisingStrength(int strength)
+        private bool SlideDenoisingStrength(int intStrength)
         {
-            _config.VoiceDenoisingStrength = strength;
+            float strength = (float)intStrength / 100;
+            ClientSettings.VoiceDenoisingStrength = strength;
             _audioInputManager.SetDenoisingStrength(strength);
-            ModConfig.Save(capi);
 
             return true;
         }

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -381,17 +381,18 @@ namespace RPVoiceChat.Gui
 
             var outputGain = ClientSettings.OutputGain * 100;
             var inputGainDBS = AudioUtils.FactorToDBs(ClientSettings.InputGain) * 10;
+            var inputThreshold = ClientSettings.InputThreshold * 100;
             var denoisingSensitivity = ClientSettings.BackgroundNoiseThreshold * 100;
             var denoisingStrength = ClientSettings.VoiceDenoisingStrength * 100;
             SetValue("configTabs", ClientSettings.ActiveConfigTab);
-            SetValue("inputDevice", _config.CurrentInputDevice ?? "Default");
-            SetValue("togglePushToTalk", _config.PushToTalkEnabled);
-            SetValue("muteMicrophone", _config.IsMuted);
-            SetValue("loopback", _config.IsLoopbackEnabled);
+            SetValue("inputDevice", ClientSettings.CurrentInputDevice ?? "Default");
+            SetValue("togglePushToTalk", ClientSettings.PushToTalkEnabled);
+            SetValue("muteMicrophone", ClientSettings.IsMuted);
+            SetValue("loopback", ClientSettings.Loopback);
             SetValue("outputGain", new dynamic[] { outputGain, 0, 200, 1, "%" });
             SetValue("inputGain", new dynamic[] { inputGainDBS, -200, 200, 1, "" });
-            SetValue("inputThreshold", new dynamic[] { _config.InputThreshold, 0, 100, 1, "" });
-            SetValue("toggleHUD", _config.IsHUDShown);
+            SetValue("inputThreshold", new dynamic[] { inputThreshold, 0, 100, 1, "" });
+            SetValue("toggleHUD", ClientSettings.ShowHud);
             SetValue("toggleMuffling", ClientSettings.Muffling);
             SetValue("toggleDenoising", ClientSettings.Denoising);
             SetValue("denoisingSensitivity", new dynamic[] { denoisingSensitivity, 0, 100, 1, "%" });
@@ -425,21 +426,18 @@ namespace RPVoiceChat.Gui
 
         private void OnTogglePushToTalk(bool enabled)
         {
-            _config.PushToTalkEnabled = enabled;
-            ModConfig.Save(capi);
+            ClientSettings.PushToTalkEnabled = enabled;
         }
 
         private void OnToggleMuted(bool enabled)
         {
-            _config.IsMuted = enabled;
-            ModConfig.Save(capi);
+            ClientSettings.IsMuted = enabled;
             capi.Event.PushEvent("rpvoicechat:hudUpdate");
         }
 
         protected void OnToggleLoopback(bool enabled)
         {
-            _config.IsLoopbackEnabled = enabled;
-            ModConfig.Save(capi);
+            ClientSettings.Loopback = enabled;
             _audioOutputManager.IsLoopbackEnabled = enabled;
         }
 
@@ -478,19 +476,18 @@ namespace RPVoiceChat.Gui
             return $"{dBValueAsText}dB";
         }
 
-        private bool SlideInputThreshold(int threshold)
+        private bool SlideInputThreshold(int intThreshold)
         {
-            _config.InputThreshold = threshold;
+            float threshold = (float)intThreshold / 100;
+            ClientSettings.InputThreshold = threshold;
             _audioInputManager.SetThreshold(threshold);
-            ModConfig.Save(capi);
 
             return true;
         }
 
         private void OnToggleHUD(bool enabled)
         {
-            _config.IsHUDShown = enabled;
-            ModConfig.Save(capi);
+            ClientSettings.ShowHud = enabled;
             capi.Event.PushEvent("rpvoicechat:hudUpdate");
         }
 

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -400,7 +400,7 @@ namespace RPVoiceChat.Gui
             SetValue("muteMicrophone", _config.IsMuted);
             SetValue("loopback", _config.IsLoopbackEnabled);
             SetValue("outputGain", new dynamic[] { _config.OutputGain, 0, 300, 1, "%" });
-            SetValue("inputGain", new dynamic[] { _config.InputGain, 0, 200, 1, "%", 100 });
+            SetValue("inputGain", new dynamic[] { _config.InputGain, 0, 400, 1, "%" });
             SetValue("inputThreshold", new dynamic[] { _config.InputThreshold, 0, 100, 1, "" });
             SetValue("toggleHUD", _config.IsHUDShown);
             SetValue("toggleMuffling", ClientSettings.GetBool("muffling", true));

--- a/src/Networking/HealthCheckException.cs
+++ b/src/Networking/HealthCheckException.cs
@@ -1,11 +1,8 @@
-using System;
-
 namespace RPVoiceChat.Networking
 {
-    public class HealthCheckException : Exception
+    public class HealthCheckException : NoStackTraceException
     {
         private const string msg = "failed readiness probe. Aborting to prevent silent malfunction.";
-        public override string StackTrace => null;
 
         public HealthCheckException(NetworkSide side) : base($"{side} {msg}") { }
     }

--- a/src/Networking/TCPNetwork/TCPConnection.cs
+++ b/src/Networking/TCPNetwork/TCPConnection.cs
@@ -187,7 +187,8 @@ namespace RPVoiceChat.Networking
             {
                 socket?.Shutdown(SocketShutdown.Both);
                 socket?.Disconnect(true);
-            } catch { }
+            }
+            catch { }
             OnDisconnected?.Invoke(isGraceful, isHalfClosed, this);
         }
 

--- a/src/Networking/UDPNetwork/UDPNetworkBase.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkBase.cs
@@ -55,11 +55,11 @@ namespace RPVoiceChat.Networking
             }
             catch (TaskCanceledException)
             {
-                logger.Warning("Device discovery got aborted, assuming public IP");
+                throw new NoStackTraceException("Device discovery got aborted");
             }
             catch (NatDeviceNotFoundException)
             {
-                logger.Warning($"Unable to port forward with UPnP, {_transportID} connection may not be available. Make sure your IP is public and UPnP is enabled if you want to use {_transportID} transport.");
+                throw new NoStackTraceException($"Unable to port forward with UPnP, {_transportID} connection may not be available. Make sure your IP is public and UPnP is enabled if you want to use {_transportID} transport.");
             }
         }
 

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -106,6 +106,7 @@ namespace RPVoiceChat
 
                 config.IsMuted = !config.IsMuted;
                 ModConfig.Save(capi);
+                capi.Event.PushEvent("rpvoicechat:hudUpdate");
                 return true;
             });
 

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -21,7 +21,7 @@ namespace RPVoiceChat
 
         protected ICoreClientAPI capi;
 
-        private ModMenuDialog configGui;
+        private ModMenuDialog modMenuDialog;
 
         private bool isReady = false;
         private bool mutePressed = false;
@@ -61,7 +61,7 @@ namespace RPVoiceChat
             client = new PlayerNetworkClient(capi, networkTransports);
 
             // Initialize gui
-            configGui = new ModMenuDialog(capi, micManager, audioOutputManager, clientSettingsRepository);
+            modMenuDialog = new ModMenuDialog(capi, micManager, audioOutputManager, clientSettingsRepository);
             capi.Gui.RegisterDialog(new SpeechIndicator(capi, micManager));
             capi.Gui.RegisterDialog(new VoiceLevelIcon(capi, micManager));
             new PlayerNameTagRenderer(capi, audioOutputManager);
@@ -81,7 +81,7 @@ namespace RPVoiceChat
 
                 voiceMenuPressed = true;
 
-                configGui.Toggle();
+                modMenuDialog.Toggle();
                 return true;
             });
 
@@ -155,7 +155,7 @@ namespace RPVoiceChat
             audioOutputManager?.Dispose();
             patchManager?.Dispose();
             client?.Dispose();
-            configGui?.Dispose();
+            modMenuDialog?.Dispose();
             clientSettingsRepository?.Dispose();
         }
     }

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -36,7 +36,6 @@ namespace RPVoiceChat
         public override void StartClientSide(ICoreClientAPI api)
         {
             capi = api;
-            ClientSettings.Init(capi);
 
             // Sneak in native dlls
             EmbeddedDllClass.ExtractEmbeddedDlls();

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -103,8 +103,7 @@ namespace RPVoiceChat
 
                 mutePressed = true;
 
-                config.IsMuted = !config.IsMuted;
-                ModConfig.Save(capi);
+                ClientSettings.IsMuted = !ClientSettings.IsMuted;
                 capi.Event.PushEvent("rpvoicechat:hudUpdate");
                 return true;
             });

--- a/src/RPVoiceChatMod.cs
+++ b/src/RPVoiceChatMod.cs
@@ -10,6 +10,7 @@ namespace RPVoiceChat
 
         public override void StartPre(ICoreAPI api)
         {
+            ClientSettings.Init(api);
             ModConfig.ReadConfig(api);
             config = ModConfig.Config;
             WorldConfig.Init(api);

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -10,7 +10,7 @@ namespace RPVoiceChat.Server
     {
         private ICoreServerAPI api;
         private List<INetworkServer> _initialTransports;
-        private List<INetworkServer> activeServers;
+        private List<INetworkServer> activeServers = new List<INetworkServer>();
         private IServerNetworkChannel handshakeChannel;
         private Dictionary<string, INetworkServer> serverByTransportID = new Dictionary<string, INetworkServer>();
         private ConnectionRequest connectionRequest;

--- a/src/Utils/AudioUtils.cs
+++ b/src/Utils/AudioUtils.cs
@@ -26,5 +26,15 @@ namespace RPVoiceChat.Utils
 
             return byteBuffer;
         }
+
+        public static float DBsToFactor(float dB)
+        {
+            return (float)Math.Pow(10, dB / 20);
+        }
+
+        public static float FactorToDBs(float factor)
+        {
+            return (float)Math.Log10(factor) * 20;
+        }
     }
 }

--- a/src/Utils/Logger.cs
+++ b/src/Utils/Logger.cs
@@ -26,8 +26,8 @@ namespace RPVoiceChat.Utils
 
         public void Error(string message, params object[] args)
         {
-            lock (main_file_lock) api.Logger.Error($"[RPVoiceChat] {message}", args);
-            lock (debug_file_lock) api.Logger.VerboseDebug($"[Error] [RPVoiceChat] {message}", args);
+            lock (main_file_lock) api.Logger?.Error($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger?.VerboseDebug($"[Error] [RPVoiceChat] {message}", args);
         }
 
         public void Debug(string message)
@@ -37,7 +37,7 @@ namespace RPVoiceChat.Utils
 
         public void Debug(string message, params object[] args)
         {
-            lock (debug_file_lock) api.Logger.Debug($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger?.Debug($"[RPVoiceChat] {message}", args);
         }
 
         public void VerboseDebug(string message)
@@ -47,7 +47,7 @@ namespace RPVoiceChat.Utils
 
         public void VerboseDebug(string message, params object[] args)
         {
-            lock (debug_file_lock) api.Logger.VerboseDebug($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger?.VerboseDebug($"[RPVoiceChat] {message}", args);
         }
 
         public void Warning(string message)
@@ -57,8 +57,8 @@ namespace RPVoiceChat.Utils
 
         public void Warning(string message, params object[] args)
         {
-            lock (main_file_lock) api.Logger.Warning($"[RPVoiceChat] {message}", args);
-            lock (debug_file_lock) api.Logger.VerboseDebug($"[Warning] [RPVoiceChat] {message}", args);
+            lock (main_file_lock) api.Logger?.Warning($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger?.VerboseDebug($"[Warning] [RPVoiceChat] {message}", args);
         }
 
         public void Notification(string message)
@@ -68,8 +68,8 @@ namespace RPVoiceChat.Utils
 
         public void Notification(string message, params object[] args)
         {
-            lock (main_file_lock) api.Logger.Notification($"[RPVoiceChat] {message}", args);
-            lock (debug_file_lock) api.Logger.VerboseDebug($"[Notification] [RPVoiceChat] {message}", args);
+            lock (main_file_lock) api.Logger?.Notification($"[RPVoiceChat] {message}", args);
+            lock (debug_file_lock) api.Logger?.VerboseDebug($"[Notification] [RPVoiceChat] {message}", args);
         }
     }
 }

--- a/src/Utils/NoStackTraceException.cs
+++ b/src/Utils/NoStackTraceException.cs
@@ -6,6 +6,6 @@ namespace RPVoiceChat
     {
         public override string StackTrace => null;
 
-        public NoStackTraceException(string message): base(message) { }
+        public NoStackTraceException(string message) : base(message) { }
     }
 }

--- a/src/Utils/NoStackTraceException.cs
+++ b/src/Utils/NoStackTraceException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace RPVoiceChat
+{
+    public class NoStackTraceException : Exception
+    {
+        public override string StackTrace => null;
+
+        public NoStackTraceException(string message): base(message) { }
+    }
+}


### PR DESCRIPTION
Fixes UDP transport being deceivingly functional (requires proper implementation of hole-punching, until then only available via UPnP and manual port forwarding)
Fixes crash when attempting to denoise fraction of audio frame (can only happen with disabled encoding)
Fixes rare crash on exit if thread with network client/server exited after Logger was disposed
Fixes initial denoising settings being set to max instead of configured values
Fixes world config not saving in singleplayer
Fixes second crash when game crashes during loading
Fixes in-memory mod config not properly updating during initial loading
Improves volume amplification:
- Old implementation:
  - Applies gain without respect for audio range
  - Clips peaks if they exceed the dynamic range
  - May result in audio clipping and non-uniform volume increase if gain was above 100% 
- New implementation:
  - Finds highest gain that won't cause clipping and lowers target gain if needed
  - Dynamically balances the gain of audio frames and smooths out gain fluctuations
  - Lowers absolute max volume to 70%
  - Will never cause clipping and allows for arbitrary high gain values (too high gain won't make player louder, but will still amplify background noise which is undesirable, so we leave default at 100% for now)

Improves Amplitude/Transmission related behaviors on abruptly discontinuous audio(muting/death)
Changes `InputGain` slider to use decibels instead of percents
Changes `InputGain` range to `{0} U (10; 1000]`% (`(-20; 20]`dBs plus "off" value)
Changes `OutputGain` range back to `[0; 200]`%
Changes default denoising strength to 10% making it a preset that only removes background noise with almost no effect on speech
Adds deactivation timeout equal to ~400ms to stop transmission "flickering"
Adds version for mod config with support for schema migrations
Removes `MaxInputThreshold` from mod config and replaces its value with half of dynamic range
Moves user settings from mod config to `ClientSettings` (some are marked as obsolete to not reset their values)
Makes `ClientSettings` more convenient/safe by adding properties for each setting
Refactors some code
Bumps patch version

