### PR TITLE
Various improvements

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
     "description": "A mod that adds in game voice proximity chat!",
-    "version": "2.3.2"
+    "version": "2.3.3"
 }

--- a/src/Audio/Effects/Denoisers/RNNoiseDenoiser.cs
+++ b/src/Audio/Effects/Denoisers/RNNoiseDenoiser.cs
@@ -63,7 +63,7 @@ namespace RPVoiceChat.Audio.Effects
                         float VAD = RNNoise.DenoiseFrame(handle, outPtr, inPtr);
                         bool isVoice = VAD > sensitivity;
                         if (isVoice)
-                            for (var i = 0; i < denoisedAudio.Length; i++)
+                            for (var i = 0; i < frameLength; i++)
                                 denoisedAudio[i] = denoisedAudio[i] * strength + rawAudio[offset + i] * (1 - strength);
 
                         Array.Copy(denoisedAudio, 0, rawAudio, offset, frameLength);

--- a/src/Audio/Output/AudioOutputManager.cs
+++ b/src/Audio/Output/AudioOutputManager.cs
@@ -36,13 +36,13 @@ namespace RPVoiceChat.Audio
 
         private ConcurrentDictionary<string, PlayerAudioSource> playerSources = new ConcurrentDictionary<string, PlayerAudioSource>();
         private PlayerAudioSource localPlayerAudioSource;
-        private ClientSettingsRepository clientSettings;
+        private ClientSettingsRepository clientSettingsRepo;
 
         public AudioOutputManager(ICoreClientAPI api, ClientSettingsRepository settingsRepository)
         {
             IsLoopbackEnabled = ClientSettings.Loopback;
             capi = api;
-            clientSettings = settingsRepository;
+            clientSettingsRepo = settingsRepository;
         }
 
         public void Launch()
@@ -95,7 +95,7 @@ namespace RPVoiceChat.Audio
 
         private void ClientLoaded()
         {
-            localPlayerAudioSource = new PlayerAudioSource(capi.World.Player, capi, clientSettings)
+            localPlayerAudioSource = new PlayerAudioSource(capi.World.Player, capi, clientSettingsRepo)
             {
                 IsLocational = false,
             };
@@ -118,7 +118,7 @@ namespace RPVoiceChat.Audio
 
         private PlayerAudioSource CreatePlayerSource(IPlayer player)
         {
-            var source = new PlayerAudioSource(player, capi, clientSettings);
+            var source = new PlayerAudioSource(player, capi, clientSettingsRepo);
             playerSources.AddOrUpdate(player.PlayerUID, source, (_, __) => source);
             source.StartPlaying();
 

--- a/src/Audio/Output/PlayerAudioSource.cs
+++ b/src/Audio/Output/PlayerAudioSource.cs
@@ -242,6 +242,10 @@ namespace RPVoiceChat.Audio
                 }
 
                 if (codec != null) audio.data = codec.Decode(audio.data);
+
+                int maxFadeDuration = 2 * audio.frequency / 1000; // 2ms
+                AudioUtils.FadeEdges(audio.data, maxFadeDuration);
+
                 buffer.QueueAudio(audio.data, audio.format, audio.frequency);
 
                 // The source can stop playing if it finishes everything in queue

--- a/src/Config/ClientSettings.cs
+++ b/src/Config/ClientSettings.cs
@@ -29,6 +29,11 @@ namespace RPVoiceChat
                 ClientSettings.capi = capi;
         }
 
+        public static void Save()
+        {
+            ((Vintagestory.Client.NoObf.ClientSettings)capi?.Settings)?.Save();
+        }
+
         public static void Set(string key, int value)
         {
             capi.Settings.Int[Key(key)] = value;

--- a/src/Config/ModConfig.cs
+++ b/src/Config/ModConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using Vintagestory.API.Common;
 
 namespace RPVoiceChat
@@ -11,24 +12,16 @@ namespace RPVoiceChat
         {
             try
             {
-                Config = LoadConfig(api);
-
-                if (Config == null)
-                {
-                    GenerateConfig(api);
-                    Config = LoadConfig(api);
-                }
-                else
-                {
-                    GenerateConfig(api, Config);
-                    Config = LoadConfig(api);
-                }
+                var config = LoadConfig(api) ?? new RPVoiceChatConfig();
+                GenerateConfig(api, config);
             }
-            catch
+            catch (Exception e)
             {
+                api.Logger.Warning($"[RPVoiceChat] Unable to load mod config, generating default one. Reason:\n{e}");
                 GenerateConfig(api);
-                Config = LoadConfig(api);
             }
+
+            Config = LoadConfig(api);
         }
 
         public static void Save(ICoreAPI api)

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -60,6 +60,7 @@ namespace RPVoiceChat
             ClientSettings.IsMuted = IsMuted;
             ClientSettings.InputThreshold = (float)InputThreshold / 100;
             ClientSettings.CurrentInputDevice = CurrentInputDevice;
+            ClientSettings.Save();
             Version = _version;
         }
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -176,6 +176,12 @@ namespace RPVoiceChat.Gui
             return true;
         }
 
+        public override bool TryClose()
+        {
+            ClientSettings.Save();
+            return base.TryClose();
+        }
+
         private void OnTitleBarCloseClicked()
         {
             TryClose();

--- a/src/Networking/TCPNetwork/TCPConnection.cs
+++ b/src/Networking/TCPNetwork/TCPConnection.cs
@@ -21,6 +21,8 @@ namespace RPVoiceChat.Networking
         private CancellationTokenSource _listeningCTS;
         private bool isDisposed = false;
         private byte[] receiveBuffer;
+        private byte[] fragmentBuffer = new byte[100*1024];
+        private int fragmentedBytes = 0;
 
         public TCPConnection(Logger logger, Socket existingSocket = null)
         {
@@ -146,7 +148,11 @@ namespace RPVoiceChat.Networking
         private List<byte[]> ParseMessages(byte[] data, int length)
         {
             var messages = new List<byte[]>();
-            var stream = new MemoryStream(data, 0, length);
+            var stream = new MemoryStream(length + fragmentedBytes);
+            stream.Write(fragmentBuffer, 0, fragmentedBytes);
+            stream.Write(data, 0, length);
+            fragmentedBytes = 0;
+            stream.Position = 0;
             using var reader = new BinaryReader(stream);
 
             try
@@ -155,17 +161,29 @@ namespace RPVoiceChat.Networking
                 while (bytesLeft > 4)
                 {
                     int messageLength = reader.ReadInt32();
-                    bytesLeft -= 4;
-                    if (messageLength > bytesLeft || messageLength < 1) break;
+                    if (messageLength > bytesLeft - 4 || messageLength < 1) break;
                     byte[] message = reader.ReadBytes(messageLength);
                     messages.Add(message);
                     bytesLeft = stream.Length - stream.Position;
                 }
-                if (bytesLeft != 0) logger.Warning($"Found fragmented packet in message buffer of {remoteEndpoint}. Proceeding to drop it. (Message queue at {length}/{receiveBuffer.Length})");
+                if (bytesLeft != 0)
+                {
+                    var remainingData = stream.ToArray();
+                    Buffer.BlockCopy(remainingData, (int)(remainingData.Length - bytesLeft), fragmentBuffer, fragmentedBytes, (int)bytesLeft);
+                    fragmentedBytes += (int)bytesLeft;
+                    if (fragmentedBytes > 30 * 1024)
+                        logger.Warning($"Buffer of packet fragments from {remoteEndpoint} is abnormally full. (Message queue at {length}/{receiveBuffer.Length}, fragmented buffer at {fragmentedBytes}/{fragmentBuffer.Length})");
+                    if (fragmentedBytes > 64 * 1024)
+                    {
+                        logger.Error($"Buffer of packet fragments from {remoteEndpoint} exceeded impossible value, discarding data. (Message queue at {length}/{receiveBuffer.Length}, fragmented buffer at {fragmentedBytes}/{fragmentBuffer.Length})");
+                        ClearNetworkStream();
+                    }
+                }
             }
             catch (Exception e)
             {
                 logger.Error($"Couldn't parse TCP messages:\n{e}");
+                ClearNetworkStream();
             }
 
             return messages;
@@ -179,6 +197,7 @@ namespace RPVoiceChat.Networking
             {
                 bytesRead = socket.Receive(receiveBuffer);
             } while (bytesRead == receiveBuffer.Length);
+            fragmentedBytes = 0;
         }
 
         public void Disconnect(bool isGraceful = true, bool isHalfClosed = false)

--- a/src/Networking/TCPNetwork/TCPNetworkServer.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkServer.cs
@@ -218,7 +218,7 @@ namespace RPVoiceChat.Networking
                         _ => connection.SendAsync(selfPingPacket, _readinessProbeCTS.Token),
                         TaskContinuationOptions.OnlyOnRanToCompletion
                     );
-                Task.Delay(1000, _readinessProbeCTS.Token).GetAwaiter().GetResult();
+                Task.Delay(5000, _readinessProbeCTS.Token).GetAwaiter().GetResult();
             }
             catch (TaskCanceledException) { }
 

--- a/src/Networking/UDPNetwork/UDPNetworkServer.cs
+++ b/src/Networking/UDPNetwork/UDPNetworkServer.cs
@@ -106,7 +106,7 @@ namespace RPVoiceChat.Networking
             try
             {
                 UdpClient.Send(selfPingPacket, selfPingPacket.Length, ownEndPoint);
-                Task.Delay(1000, _readinessProbeCTS.Token).GetAwaiter().GetResult();
+                Task.Delay(5000, _readinessProbeCTS.Token).GetAwaiter().GetResult();
             }
             catch (TaskCanceledException) { }
 

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -151,6 +151,7 @@ namespace RPVoiceChat
 
         public override void Dispose()
         {
+            ClientSettings.Save();
             micManager?.Dispose();
             audioOutputManager?.Dispose();
             patchManager?.Dispose();

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -105,6 +105,7 @@ namespace RPVoiceChat
 
                 ClientSettings.IsMuted = !ClientSettings.IsMuted;
                 capi.Event.PushEvent("rpvoicechat:hudUpdate");
+                ClientSettings.Save();
                 return true;
             });
 

--- a/src/Utils/AudioUtils.cs
+++ b/src/Utils/AudioUtils.cs
@@ -36,5 +36,88 @@ namespace RPVoiceChat.Utils
         {
             return (float)Math.Log10(factor) * 20;
         }
+
+        public static void FadeEdges(byte[] data, int maxFadeDuration)
+        {
+            FadeEdge(data, maxFadeDuration, false);
+            FadeEdge(data, maxFadeDuration, true);
+        }
+
+        public static void FadeEdge(byte[] data, int maxFadeDuration, bool isRightEdge)
+        {
+            int sampleCount = data.Length / sizeof(short);
+            int startIndex = 0;
+            int endIndex = maxFadeDuration;
+            TransformDelegate transform = e => e;
+            if (isRightEdge)
+            {
+                startIndex = sampleCount - maxFadeDuration - 1;
+                endIndex = sampleCount - 1;
+                transform = e => 1 - e;
+            }
+
+            int zeroCrossingIndex = -1;
+            double? lastPcm = null;
+            for (var i = startIndex; i < endIndex; i++)
+            {
+                var pcm = (double)BitConverter.ToInt16(data, i * sizeof(short));
+                if (lastPcm == null || pcm * lastPcm > 0)
+                {
+                    lastPcm = pcm;
+                    continue;
+                }
+                zeroCrossingIndex = i;
+                if (!isRightEdge) break;
+                lastPcm = pcm;
+                continue;
+            }
+
+            if (zeroCrossingIndex == -1)
+            {
+                Fade(data, startIndex, endIndex, transform);
+                return;
+            }
+
+            var silenceFrom = 0;
+            var silenceTo = zeroCrossingIndex * sizeof(short);
+            if (isRightEdge)
+            {
+                silenceFrom = zeroCrossingIndex * sizeof(short);
+                silenceTo = sampleCount * sizeof(short);
+            }
+
+            var silenceBytes = silenceTo - silenceFrom;
+            var silence = new byte[silenceBytes];
+            Buffer.BlockCopy(silence, 0, data, silenceFrom, silenceBytes);
+        }
+
+        /// <summary>
+        /// A function used to describe percentage change of some value
+        /// </summary>
+        /// <param name="progress">Normalized(percentage) distance in the interval with 0 corresponding to the first sample and 1 to last sample</param>
+        /// <returns>Factor that an audio sample should be adjusted by</returns>
+        public delegate double TransformDelegate(double progress);
+
+        /// <summary>
+        /// Iterates over specified closed interval and multiplies every value with the result of transform function
+        /// </summary>
+        /// <param name="data">Raw, unencoded, mono-channel PCM data</param>
+        /// <param name="startIndex">Index of a sample(not the byte) to start fading from</param>
+        /// <param name="endIndex">Index of a last sample(not the byte) that will be affected by fade</param>
+        /// <param name="transform">A <see cref="TransformDelegate">TransformDelegate</see> that will be used to adjust fading speed or direction</param>
+        public static void Fade(byte[] data, int startIndex, int endIndex, TransformDelegate transform)
+        {
+            int fadeDuration = endIndex - startIndex;
+            short[] pcmBuffer = new short[fadeDuration + 1];
+            for (var i = startIndex; i <= endIndex; i++)
+            {
+                var pcm = (double)BitConverter.ToInt16(data, i * sizeof(short));
+                var pcmIndex = i - startIndex;
+                var fadeMultiplier = (double)pcmIndex / fadeDuration;
+                pcm *= transform(fadeMultiplier);
+                pcmBuffer[pcmIndex] = (short)pcm;
+            }
+            Buffer.BlockCopy(pcmBuffer, 0, data, startIndex * sizeof(short), pcmBuffer.Length * sizeof(short));
+        }
     }
 }


### PR DESCRIPTION
Fixes crash on denoising if denoising strength is not 100 and audio encoding is disabled
Makes `ClientSettings` save more actively instead of only when the game is closed
Refactors mod config loading and makes issues with it more transparent
Enforces zero crossings at the edges of audio chunks to prevent audible clicks when audio is discontinuous:
- This has to be done on the receiver side because Opus has no respect for continuity of audio, removing enforced zero crossings during encoding
- The algorithm is as follows:
1. Search the 2ms window at the edges of the audio packet for zero crossings
2. If there is any, pick the one closest to the respective edge and replace all audio samples between it and the edge with 0
3. If there is none, linearly lower/rise the amplitude so that it is equal to 0 at the edge and is unaffected at the end of 2ms window
- This makes all audio packets continuous without introducing any audible difference other than removal of clicks/pops

Increases server's health check timeout from 1s to 5s in case server owner directs traffic through remote reverse proxy/tunnel
Makes CustomTCP server attempt to reassemble fragmented messages instead of just discarding them. This should reduce packet loss, especially if they were intentionally fragmented by ISP/network proxy/other third party 
Bumps patch version