### PR TITLE
Make NativeTCP unaffected by main thread lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The settings relevant to server owners are:
 - `ServerPort` - The port to use for the voice networking. The default value is `52525`.
 - `ServerIP` - The ip for clients to connect to. Leave it as is unless you are playing through LAN, in which case set it to address of your private network(e.g. `"25.95.127.13"`). The default value is `null`.
 - `AdditionalContent` - Whether additional modded content(bells, horns, etc) should be enabled. The default value is `true`.
+- `UseCustomNetworkServers` - Can be used to enable UDP and CustomTCP transports. As of v2.3.4 NativeTCP is unaffected by lag so there is little to no benefits from running custom servers. The default value is `false`.
 
 You can also use `/rpvc [command]` to access world-specific settings:
 - `shout` - Sets the shout distance in blocks. The default value is `25`.

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
     "description": "A mod that adds in game voice proximity chat!",
-    "version": "2.3.3"
+    "version": "2.3.4"
 }

--- a/src/Audio/Output/PlayerAudioSource.cs
+++ b/src/Audio/Output/PlayerAudioSource.cs
@@ -209,11 +209,7 @@ namespace RPVoiceChat.Audio
         {
             lock (ordering_queue_lock)
             {
-                if (orderingQueue.ContainsKey(sequenceNumber))
-                {
-                    Logger.client.VerboseDebug($"Audio sequence {sequenceNumber} already received, skipping enqueueing");
-                    return;
-                }
+                if (orderingQueue.ContainsKey(sequenceNumber)) return;
 
                 if (lastAudioSequenceNumber >= sequenceNumber)
                 {

--- a/src/Client/PlayerNetworkClient.cs
+++ b/src/Client/PlayerNetworkClient.cs
@@ -77,7 +77,6 @@ namespace RPVoiceChat.Client
             }
             isConnected = true;
 
-            if (activeTransports[0] is NativeNetworkClient) api.Event.EnqueueMainThreadTask(() => api.ShowChatMessage($"<strong>[RPVoiceChat]: Failed to connect with custom network clients, audio stability will be degraded</strong>"), "rpvoicechat:PlayerNetworkClient");
             if (activeTransports.Count > 0) return;
             IEnumerable<string> serverTransportIDs = serverConnections.Select(e => e.Transport);
             throw new Exception($"Failed to connect to the server. Supported transports: {string.Join(", ", serverTransportIDs)}");
@@ -123,7 +122,6 @@ namespace RPVoiceChat.Client
             if (isShutdown) return;
             activeTransports.Remove(transport);
             transport.Dispose();
-            api.Event.EnqueueMainThreadTask(() => api.ShowChatMessage($"<strong>[RPVoiceChat]: Failed to reconnect with {transportID} client, audio stability will be degraded</strong>"), "rpvoicechat:PlayerNetworkClient");
         }
 
         private bool Reconnect(IExtendedNetworkClient transport)

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -19,6 +19,7 @@ namespace RPVoiceChat
         public int ServerPort = 52525;
         public string ServerIP = null;
         public bool AdditionalContent = true;
+        public bool UseCustomNetworkServers = false;
 
         // --- Client Settings ---
         // These are meant to be set by the client, but are
@@ -43,6 +44,7 @@ namespace RPVoiceChat
             ServerPort = previousConfig.ServerPort;
             ServerIP = previousConfig.ServerIP;
             AdditionalContent = previousConfig.AdditionalContent;
+            UseCustomNetworkServers = previousConfig.UseCustomNetworkServers;
 
             PushToTalkEnabled = previousConfig.PushToTalkEnabled;
             IsMuted = previousConfig.IsMuted;

--- a/src/Networking/IExtendedNetworkServer.cs
+++ b/src/Networking/IExtendedNetworkServer.cs
@@ -2,7 +2,6 @@ namespace RPVoiceChat.Networking
 {
     public interface IExtendedNetworkServer : INetworkServer
     {
-        public void Launch();
         public void PlayerConnected(string playerId, ConnectionInfo connectionInfo);
         public void PlayerDisconnected(string playerId);
     }

--- a/src/Networking/INetworkServer.cs
+++ b/src/Networking/INetworkServer.cs
@@ -6,6 +6,7 @@ namespace RPVoiceChat.Networking
     {
         public event Action<AudioPacket> AudioPacketReceived;
 
+        public void Launch();
         public ConnectionInfo GetConnectionInfo();
         public string GetTransportID();
         public bool SendPacket(NetworkPacket packet, string playerId);

--- a/src/Networking/NativeNetwork/NativeNetworkBase.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkBase.cs
@@ -17,9 +17,6 @@ namespace RPVoiceChat.Networking
             return _transportID;
         }
 
-        public void Dispose()
-        {
-            // Game handles disposal for us
-        }
+        public virtual void Dispose() { }
     }
 }

--- a/src/Networking/NativeNetwork/NativeNetworkBase.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkBase.cs
@@ -16,7 +16,5 @@ namespace RPVoiceChat.Networking
         {
             return _transportID;
         }
-
-        public virtual void Dispose() { }
     }
 }

--- a/src/Networking/NativeNetwork/NativeNetworkBase.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkBase.cs
@@ -5,6 +5,7 @@ namespace RPVoiceChat.Networking
     public abstract class NativeNetworkBase
     {
         protected const string ChannelName = "RPAudioChannel";
+        protected const string SPChannelName = $"{ChannelName}_SP";
         protected const string _transportID = "NativeTCP";
 
         public NativeNetworkBase(ICoreAPI api)

--- a/src/Networking/NativeNetwork/NativeNetworkClient.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkClient.cs
@@ -1,6 +1,6 @@
 using HarmonyLib;
-using RPVoiceChat.Utils;
 using System;
+using System.Reflection;
 using Vintagestory.API.Client;
 using Vintagestory.Client.NoObf;
 
@@ -23,11 +23,13 @@ namespace RPVoiceChat.Networking
             return true;
         }
 
+        private static FieldInfo channelIdField = AccessTools.Field(typeof(NetworkChannel), "channelId");
+
         private bool ProcessInBackground(int channelId, Packet_CustomPacket customPacket)
         {
             if (channel is not NetworkChannel nativeChannel) return false;
 
-            var expectedChannelId = (int)AccessTools.Field(typeof(NetworkChannel), "channelId").GetValue(channel);
+            var expectedChannelId = (int)channelIdField.GetValue(channel);
             if (channelId != expectedChannelId) return false;
 
             nativeChannel.OnPacket(customPacket);

--- a/src/Networking/NativeNetwork/NativeNetworkClient.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkClient.cs
@@ -10,15 +10,19 @@ namespace RPVoiceChat.Networking
     {
         public event Action<AudioPacket> OnAudioReceived;
         private IClientNetworkChannel channel;
+        private IClientNetworkChannel singleplayerChannel;
 
         public NativeNetworkClient(ICoreClientAPI api) : base(api)
         {
             channel = api.Network.GetChannel(ChannelName).SetMessageHandler<AudioPacket>(HandleAudioPacket);
+            if (api.IsSinglePlayer)
+                singleplayerChannel = api.Network.RegisterChannel(SPChannelName).RegisterMessageType<AudioPacket>();
             SystemNetworkProcessPatch.OnProcessInBackground += ProcessInBackground;
         }
 
         public bool SendAudioToServer(AudioPacket packet)
         {
+            var channel = singleplayerChannel ?? this.channel;
             channel.SendPacket(packet);
             return true;
         }

--- a/src/Networking/NativeNetwork/NativeNetworkClient.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkClient.cs
@@ -39,7 +39,7 @@ namespace RPVoiceChat.Networking
             OnAudioReceived?.Invoke(packet);
         }
 
-        public override void Dispose()
+        public void Dispose()
         {
             SystemNetworkProcessPatch.OnProcessInBackground -= ProcessInBackground;
         }

--- a/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
+++ b/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
@@ -1,0 +1,104 @@
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Vintagestory.API.Server;
+using Vintagestory.Common;
+using Vintagestory.Server;
+
+namespace RPVoiceChat.Networking
+{
+    public class ServerSystemNetworkProcess: IDisposable
+    {
+        public event Func<int, Packet_CustomPacket, IServerPlayer, bool> OnProcessInBackground;
+
+        private const int _customPacketId = 23;
+        private ICoreServerAPI api;
+        private Thread packetProcessingThread;
+        private CancellationTokenSource _packetProcessingCTS;
+
+        public ServerSystemNetworkProcess(ICoreServerAPI sapi)
+        {
+            api = sapi;
+            packetProcessingThread = new Thread(NetworkProcess);
+            _packetProcessingCTS = new CancellationTokenSource();
+        }
+
+        public void Launch()
+        {
+            packetProcessingThread.Start(_packetProcessingCTS.Token);
+        }
+
+        private static FieldInfo senderConnectionField = AccessTools.Field(typeof(NetIncomingMessage), "SenderConnection");
+        private static FieldInfo messageField = AccessTools.Field(typeof(NetIncomingMessage), "message");
+        private static FieldInfo messageLengthField = AccessTools.Field(typeof(NetIncomingMessage), "messageLength");
+
+        private void NetworkProcess(object cancellationToken)
+        {
+            var ct = (CancellationToken)cancellationToken;
+            while (packetProcessingThread.IsAlive && !ct.IsCancellationRequested)
+            {
+                NetIncomingMessage msg;
+                while ((msg = TcpNetServerPatch.ReadMessage()) != null)
+                {
+                    var connection = (NetConnection)senderConnectionField.GetValue(msg);
+                    var player = ResolveServerPlayer(connection);
+                    if (player == null) continue;
+                    var data = (byte[])messageField.GetValue(msg);
+                    var length = (int)messageLengthField.GetValue(msg);
+                    TryReadPacket(data, length, player);
+                }
+                Thread.Sleep(1);
+            }
+        }
+
+        private void TryReadPacket(byte[] data, int dataLength, IServerPlayer sender)
+        {
+            Packet_Client packet = new Packet_Client();
+            Packet_ClientSerializer.DeserializeBuffer(data, dataLength, packet);
+
+            ProcessInBackground(packet, sender);
+        }
+
+        private static FieldInfo packetIdField = AccessTools.Field(typeof(Packet_Client), "Id");
+        private static FieldInfo customPacketField = AccessTools.Field(typeof(Packet_Client), "CustomPacket");
+        private static FieldInfo channelIdField = AccessTools.Field(typeof(Packet_CustomPacket), "ChannelId");
+
+        private bool ProcessInBackground(Packet_Client packet, IServerPlayer sender)
+        {
+            var id = (int)packetIdField.GetValue(packet);
+            if (id != _customPacketId) return false;
+
+            var customPacket = (Packet_CustomPacket)customPacketField.GetValue(packet);
+            var channelId = (int)channelIdField.GetValue(customPacket);
+            bool processed = OnProcessInBackground?.Invoke(channelId, customPacket, sender) ?? false;
+            return processed;
+        }
+
+        private static FieldInfo FromSocketListenerField = AccessTools.Field(typeof(ConnectedClient), "FromSocketListener");
+        private static FieldInfo SocketField = AccessTools.Field(typeof(ConnectedClient), "socket");
+        private static FieldInfo PlayerField = AccessTools.Field(typeof(ConnectedClient), "Player");
+
+        private IServerPlayer ResolveServerPlayer(NetConnection connection)
+        {
+            foreach (KeyValuePair<int, ConnectedClient> val in ((ServerMain)api.World).Clients)
+            {
+                var connectedClient = val.Value;
+                var server = (NetServer)FromSocketListenerField.GetValue(connectedClient);
+                var serverConnection = (NetConnection)SocketField.GetValue(connectedClient);
+                if (server is TcpNetServer && serverConnection.EqualsConnection(connection))
+                    return (IServerPlayer)PlayerField.GetValue(connectedClient);
+            }
+            return null;
+        }
+
+        public void Dispose()
+        {
+            _packetProcessingCTS?.Cancel();
+            _packetProcessingCTS?.Dispose();
+            _packetProcessingCTS = null;
+            OnProcessInBackground = null;
+        }
+    }
+}

--- a/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
+++ b/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
@@ -9,7 +9,7 @@ using Vintagestory.Server;
 
 namespace RPVoiceChat.Networking
 {
-    public class ServerSystemNetworkProcess: IDisposable
+    public class ServerSystemNetworkProcess : IDisposable
     {
         public event Func<int, Packet_CustomPacket, IServerPlayer, bool> OnProcessInBackground;
 

--- a/src/Networking/TCPNetwork/TCPConnection.cs
+++ b/src/Networking/TCPNetwork/TCPConnection.cs
@@ -21,7 +21,7 @@ namespace RPVoiceChat.Networking
         private CancellationTokenSource _listeningCTS;
         private bool isDisposed = false;
         private byte[] receiveBuffer;
-        private byte[] fragmentBuffer = new byte[100*1024];
+        private byte[] fragmentBuffer = new byte[100 * 1024];
         private int fragmentedBytes = 0;
 
         public TCPConnection(Logger logger, Socket existingSocket = null)

--- a/src/Patches/NetworkAPI.cs
+++ b/src/Patches/NetworkAPI.cs
@@ -1,0 +1,34 @@
+using HarmonyLib;
+using System;
+using System.Reflection;
+using Vintagestory.Server;
+
+namespace RPVoiceChat
+{
+    /// <summary>
+    /// Patches <b>server's</b> NetworkAPI to allow skipping handling of packets over certain channels
+    /// </summary>
+    static class NetworkAPIPatch
+    {
+        public static event Func<int, bool> OnHandleCustomPacket;
+
+        public static void Patch(Harmony harmony)
+        {
+            var OriginalMethod = AccessTools.Method(typeof(NetworkAPI), nameof(HandleCustomPacket));
+            var PrefixMethod = AccessTools.Method(typeof(NetworkAPIPatch), nameof(HandleCustomPacket));
+            harmony.Patch(OriginalMethod, prefix: new HarmonyMethod(PrefixMethod));
+        }
+
+        private static FieldInfo CustomPacketField = AccessTools.Field(typeof(Packet_Client), "CustomPacket");
+        private static FieldInfo ChannelIdField = AccessTools.Field(typeof(Packet_CustomPacket), "ChannelId");
+
+        public static bool HandleCustomPacket(Packet_Client packet)
+        {
+            var customPacket = (Packet_CustomPacket)CustomPacketField.GetValue(packet);
+            var channelId = (int)ChannelIdField.GetValue(customPacket);
+            bool isAlreadyHandled = OnHandleCustomPacket?.Invoke(channelId) ?? false;
+            bool shouldHandle = !isAlreadyHandled;
+            return shouldHandle;
+        }
+    }
+}

--- a/src/Patches/PatchManager.cs
+++ b/src/Patches/PatchManager.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using System;
+using Vintagestory.API.Common;
 
 namespace RPVoiceChat
 {
@@ -12,13 +13,24 @@ namespace RPVoiceChat
             harmony = new Harmony(harmonyId);
         }
 
-        public void Patch()
+        public void Patch(ICoreAPI api)
+        {
+            if ((api.Side & EnumAppSide.Client) != 0) PatchClient();
+            if ((api.Side & EnumAppSide.Server) != 0) PatchServer();
+        }
+
+        private void PatchClient()
         {
             EntityNameTagRendererRegistryPatch.Patch(harmony);
             GuiDialogCreateCharacterPatch.Patch(harmony);
             GuiElementSliderPatch.Patch(harmony);
             LoadedSoundNativePatch.Patch(harmony);
             SystemNetworkProcessPatch.Patch(harmony);
+        }
+
+        private void PatchServer()
+        {
+            TcpNetServerPatch.Patch(harmony);
         }
 
         public void Unpatch()

--- a/src/Patches/PatchManager.cs
+++ b/src/Patches/PatchManager.cs
@@ -30,6 +30,7 @@ namespace RPVoiceChat
 
         private void PatchServer()
         {
+            NetworkAPIPatch.Patch(harmony);
             TcpNetServerPatch.Patch(harmony);
         }
 

--- a/src/Patches/PatchManager.cs
+++ b/src/Patches/PatchManager.cs
@@ -18,6 +18,7 @@ namespace RPVoiceChat
             GuiDialogCreateCharacterPatch.Patch(harmony);
             GuiElementSliderPatch.Patch(harmony);
             LoadedSoundNativePatch.Patch(harmony);
+            SystemNetworkProcessPatch.Patch(harmony);
         }
 
         public void Unpatch()

--- a/src/Patches/SystemNetworkProcess.cs
+++ b/src/Patches/SystemNetworkProcess.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using System;
+using System.Reflection;
 using Vintagestory.Client.NoObf;
 
 namespace RPVoiceChat
@@ -17,13 +18,17 @@ namespace RPVoiceChat
             harmony.Patch(OriginalMethod, postfix: new HarmonyMethod(PostfixMethod));
         }
 
+        private static FieldInfo packetIdField = AccessTools.Field(typeof(Packet_Server), "Id");
+        private static FieldInfo customPacketField = AccessTools.Field(typeof(Packet_Server), "CustomPacket");
+        private static FieldInfo channelIdField = AccessTools.Field(typeof(Packet_CustomPacket), "ChannelId");
+
         public static void ProcessInBackground(ref bool __result, Packet_Server packet)
         {
-            var id = (int)AccessTools.Field(typeof(Packet_Server), "Id").GetValue(packet);
+            var id = (int)packetIdField.GetValue(packet);
             if (id != _customPacketId) return;
 
-            var customPacket = (Packet_CustomPacket)AccessTools.Field(typeof(Packet_Server), "CustomPacket").GetValue(packet);
-            var channelId = (int)AccessTools.Field(typeof(Packet_CustomPacket), "ChannelId").GetValue(customPacket);
+            var customPacket = (Packet_CustomPacket)customPacketField.GetValue(packet);
+            var channelId = (int)channelIdField.GetValue(customPacket);
             bool processed = OnProcessInBackground?.Invoke(channelId, customPacket) ?? false;
             if (processed) __result = true;
         }

--- a/src/Patches/SystemNetworkProcess.cs
+++ b/src/Patches/SystemNetworkProcess.cs
@@ -5,6 +5,9 @@ using Vintagestory.Client.NoObf;
 
 namespace RPVoiceChat
 {
+    /// <summary>
+    /// Allows TCP messages from custom channels received by client to be processed in separate thread
+    /// </summary>
     static class SystemNetworkProcessPatch
     {
         public static event Func<int, Packet_CustomPacket, bool> OnProcessInBackground;

--- a/src/Patches/SystemNetworkProcess.cs
+++ b/src/Patches/SystemNetworkProcess.cs
@@ -1,0 +1,31 @@
+using HarmonyLib;
+using System;
+using Vintagestory.Client.NoObf;
+
+namespace RPVoiceChat
+{
+    static class SystemNetworkProcessPatch
+    {
+        public static event Func<int, Packet_CustomPacket, bool> OnProcessInBackground;
+
+        private const int _customPacketId = 55;
+
+        public static void Patch(Harmony harmony)
+        {
+            var OriginalMethod = AccessTools.Method(typeof(SystemNetworkProcess), nameof(ProcessInBackground));
+            var PostfixMethod = AccessTools.Method(typeof(SystemNetworkProcessPatch), nameof(ProcessInBackground));
+            harmony.Patch(OriginalMethod, postfix: new HarmonyMethod(PostfixMethod));
+        }
+
+        public static void ProcessInBackground(ref bool __result, Packet_Server packet)
+        {
+            var id = (int)AccessTools.Field(typeof(Packet_Server), "Id").GetValue(packet);
+            if (id != _customPacketId) return;
+
+            var customPacket = (Packet_CustomPacket)AccessTools.Field(typeof(Packet_Server), "CustomPacket").GetValue(packet);
+            var channelId = (int)AccessTools.Field(typeof(Packet_CustomPacket), "ChannelId").GetValue(customPacket);
+            bool processed = OnProcessInBackground?.Invoke(channelId, customPacket) ?? false;
+            if (processed) __result = true;
+        }
+    }
+}

--- a/src/Patches/TcpNetServer.cs
+++ b/src/Patches/TcpNetServer.cs
@@ -8,6 +8,9 @@ using Vintagestory.Server;
 
 namespace RPVoiceChat
 {
+    /// <summary>
+    /// Copies TCP messages received by server into own message queue for further processing from separate thread
+    /// </summary>
     static class TcpNetServerPatch
     {
         private static readonly CodeInstruction anchor = new CodeInstruction(

--- a/src/Patches/TcpNetServer.cs
+++ b/src/Patches/TcpNetServer.cs
@@ -1,0 +1,70 @@
+using HarmonyLib;
+using RPVoiceChat.Utils;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using Vintagestory.Common;
+using Vintagestory.Server;
+
+namespace RPVoiceChat
+{
+    static class TcpNetServerPatch
+    {
+        private static readonly CodeInstruction anchor = new CodeInstruction(
+            OpCodes.Callvirt,
+            AccessTools.Method(typeof(Queue<NetIncomingMessage>), "Enqueue")
+        );
+        private static readonly List<CodeInstruction> patch = new List<CodeInstruction>() {
+            // Pass first local variable (msg)
+            new CodeInstruction(OpCodes.Ldloc_0),
+            // Into OnReceivedMessage
+            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TcpNetServerPatch), nameof(OnReceivedMessage)))
+        };
+        private static Queue<NetIncomingMessage> messages = new Queue<NetIncomingMessage>();
+
+        public static void Patch(Harmony harmony)
+        {
+            var OriginalMethod = AccessTools.Method(typeof(TcpNetServer), "server_ReceivedMessage");
+            var TranspilerMethod = AccessTools.Method(typeof(TcpNetServerPatch), nameof(server_ReceivedMessage_Transpiler));
+            harmony.Patch(OriginalMethod, transpiler: new HarmonyMethod(TranspilerMethod));
+        }
+
+        public static IEnumerable<CodeInstruction> server_ReceivedMessage_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var patchIndex = -1;
+            var codes = new List<CodeInstruction>(instructions);
+            for (var i = 0; i < codes.Count; i++)
+            {
+                var codeInstr = codes[i];
+                if (codeInstr.opcode != anchor.opcode) continue;
+                if (codeInstr.operand != anchor.operand) continue;
+                patchIndex = i;
+                break;
+            }
+
+            if (patchIndex == -1)
+            {
+                Logger.server.Error("Couldn't find transpiler anchor for TcpNetServer patch");
+                return instructions;
+            }
+
+            codes.InsertRange(patchIndex, patch);
+            Logger.server.Notification("TcpNetServer was successfully patched");
+            return codes.AsEnumerable();
+        }
+
+        private static void OnReceivedMessage(NetIncomingMessage msg)
+        {
+            lock (messages) messages.Enqueue(msg);
+        }
+
+        public static NetIncomingMessage ReadMessage()
+        {
+            lock (messages)
+            {
+                if (messages.Count == 0) return null;
+                return messages.Dequeue();
+            }
+        }
+    }
+}

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -16,7 +16,6 @@ namespace RPVoiceChat
         private ClientSettingsRepository clientSettingsRepository;
         private MicrophoneManager micManager;
         private AudioOutputManager audioOutputManager;
-        private PatchManager patchManager;
         private PlayerNetworkClient client;
 
         protected ICoreClientAPI capi;
@@ -44,11 +43,9 @@ namespace RPVoiceChat
             // Init data repositories
             clientSettingsRepository = new ClientSettingsRepository(capi.Logger);
 
-            // Init microphone, audio output and harmony patch managers
+            // Init microphone and audio output managers
             micManager = new MicrophoneManager(capi);
             audioOutputManager = new AudioOutputManager(capi, clientSettingsRepository);
-            patchManager = new PatchManager(modID);
-            patchManager.Patch();
 
             // Init voice chat client
             bool forwardPorts = !config.ManualPortForwarding;
@@ -155,7 +152,6 @@ namespace RPVoiceChat
             ClientSettings.Save();
             micManager?.Dispose();
             audioOutputManager?.Dispose();
-            patchManager?.Dispose();
             client?.Dispose();
             modMenuDialog?.Dispose();
             clientSettingsRepository?.Dispose();

--- a/src/RPVoiceChatMod.cs
+++ b/src/RPVoiceChatMod.cs
@@ -5,8 +5,9 @@ namespace RPVoiceChat
 {
     public abstract class RPVoiceChatMod : ModSystem
     {
-        protected RPVoiceChatConfig config;
         public static readonly string modID = "rpvoicechat";
+        protected RPVoiceChatConfig config;
+        private PatchManager patchManager;
 
         public override void StartPre(ICoreAPI api)
         {
@@ -19,8 +20,16 @@ namespace RPVoiceChat
 
         public override void Start(ICoreAPI api)
         {
+            patchManager = new PatchManager(modID);
+            patchManager.Patch(api);
+
             ItemRegistry.RegisterItems(api);
             BlockRegistry.RegisterBlocks(api);
+        }
+
+        public override void Dispose()
+        {
+            patchManager?.Dispose();
         }
     }
 }

--- a/src/RPVoiceChatServer.cs
+++ b/src/RPVoiceChatServer.cs
@@ -19,10 +19,13 @@ namespace RPVoiceChat
             bool forwardPorts = !config.ManualPortForwarding;
             var networkTransports = new List<INetworkServer>()
             {
-                new UDPNetworkServer(config.ServerPort, config.ServerIP, forwardPorts),
-                new TCPNetworkServer(config.ServerPort, config.ServerIP, forwardPorts),
                 new NativeNetworkServer(api)
             };
+            if (config.UseCustomNetworkServers)
+            {
+                networkTransports.Insert(0, new UDPNetworkServer(config.ServerPort, config.ServerIP, forwardPorts));
+                networkTransports.Insert(1, new TCPNetworkServer(config.ServerPort, config.ServerIP, forwardPorts));
+            }
 
             server = new GameServer(sapi, networkTransports);
             server.Launch();

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -89,9 +89,7 @@ namespace RPVoiceChat.Server
         {
             var transportID = server.GetTransportID();
             Logger.server.Notification($"Launching {transportID} server");
-            if (server is IExtendedNetworkServer extendedServer)
-                extendedServer?.Launch();
-
+            server.Launch();
             activeServers.Add(server);
             serverByTransportID.Add(transportID, server);
             Logger.server.Notification($"{transportID} server started");


### PR DESCRIPTION
Patches `SystemNetworkProcess` to off-thread client side message processing
Patches `TcpNetworkServer` to duplicate message queue, and read custom packets from it in a separate thread
Patches server's `NetworkAPI` to skip processing of custom packets over certain channels (solves packet duplication caused by patch above ^)
Removes chat warnings about NativeTCP being the only available transport
Makes NativeTCP default transport since it is more stable and doesn't require any manual setup/configuration
Adds a config option to enable custom transports if for whatever reason people still want to use them
Updates documentation according to changes
Bumps patch version


**Note:**
In a singleplayer world opened to network, host's speech will still be affected by server lag because it uses `DummyNetServer` to simulate networking. Host's client lag won't contribute to it however and speech of others won't be affected by lag at all.
Fixing that would be rather difficult and singleplayer worlds should not lag much so this isn't a problem that worth addressing.
If that ever poses an issue to someone, workarounds would be:
1. Use a dedicated server(`VintagestoryServer.exe`), it is just as easy to host and provides general performance improvement
2. Enable custom transports in the mod config (Not recommended as it will affect all players and increase resource consumption).