### PR TITLE
Hotfix for incorrect audio input device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ launchSettings.json
 *.user
 *.userosscache
 *.sln.docstates
-*.dll
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The settings relevant to server owners are:
 - `ServerPort` - The port to use for the voice networking. The default value is `52525`.
 - `ServerIP` - The ip for clients to connect to. Leave it as is unless you are playing through LAN, in which case set it to address of your private network(e.g. `"25.95.127.13"`). The default value is `null`.
 - `AdditionalContent` - Whether additional modded content(bells, horns, etc) should be enabled. The default value is `true`.
+- `UseCustomNetworkServers` - Can be used to enable UDP and CustomTCP transports. As of v2.3.4 NativeTCP is unaffected by lag so there is little to no benefits from running custom servers. The default value is `false`.
 
 You can also use `/rpvc [command]` to access world-specific settings:
 - `shout` - Sets the shout distance in blocks. The default value is `25`.

--- a/RPVoiceChat.csproj
+++ b/RPVoiceChat.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net462</TargetFramework>
-		<LangVersion>9</LangVersion>
+		<TargetFramework>net7.0</TargetFramework>
+		<LangVersion>11</LangVersion>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
 		<RootNamespace>RPVoiceChat</RootNamespace>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -33,9 +34,13 @@
 			<HintPath>$(VINTAGE_STORY)/Mods/VSEssentials.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<Reference Include="OpenTK">
-			<HintPath>$(VINTAGE_STORY)/Lib/OpenTK.dll</HintPath>
-			<Private>False</Private>
+		<Reference Include="OpenAL">
+			<HintPath>Lib/OpenTK.Audio.OpenAL.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+		<Reference Include="OpenTK.Mathematics">
+			<HintPath>Lib/OpenTK.Mathematics.dll</HintPath>
+			<Private>True</Private>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
 			<HintPath>$(VINTAGE_STORY)/Lib/Newtonsoft.Json.dll</HintPath>
@@ -74,7 +79,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Concentus" Version="1.1.7" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 	</ItemGroup>
 </Project>

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
     "description": "A mod that adds in game voice proximity chat!",
-    "version": "1.5.2"
+    "version": "2.3.4"
 }

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
     "description": "A mod that adds in game voice proximity chat!",
-    "version": "2.3.4"
+    "version": "2.3.5"
 }

--- a/src/Audio/Effects/EffectReverb.cs
+++ b/src/Audio/Effects/EffectReverb.cs
@@ -6,26 +6,24 @@ namespace RPVoiceChat.Audio.Effects
     {
         private int effect;
         private int slot;
-        private EffectsExtension efx;
-        public ReverbEffect(EffectsExtension efx, int source)
+
+        public ReverbEffect(int source)
         {
+            effect = ALC.EFX.GenEffect();
+            slot = ALC.EFX.GenAuxiliaryEffectSlot();
 
-            this.efx = efx;
-            effect = efx.GenEffect();
-            slot = efx.GenAuxiliaryEffectSlot();
+            ALC.EFX.Effect(effect, EffectInteger.EffectType, (int)EffectType.Reverb);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbDecayTime, 3.0f);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbDecayHFRatio, 0.91f);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbDensity, 0.7f);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbDiffusion, 0.9f);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbRoomRolloffFactor, 3.1f);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbReflectionsGain, 0.723f);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbReflectionsDelay, 0.03f);
+            ALC.EFX.Effect(effect, EffectFloat.ReverbGain, 0.23f);
 
-            efx.BindEffect(effect, EfxEffectType.Reverb);
-            efx.Effect(effect, EfxEffectf.ReverbDecayTime, 3.0f);
-            efx.Effect(effect, EfxEffectf.ReverbDecayHFRatio, 0.91f);
-            efx.Effect(effect, EfxEffectf.ReverbDensity, 0.7f);
-            efx.Effect(effect, EfxEffectf.ReverbDiffusion, 0.9f);
-            efx.Effect(effect, EfxEffectf.ReverbRoomRolloffFactor, 3.1f);
-            efx.Effect(effect, EfxEffectf.ReverbReflectionsGain, 0.723f);
-            efx.Effect(effect, EfxEffectf.ReverbReflectionsDelay, 0.03f);
-            efx.Effect(effect, EfxEffectf.ReverbGain, 0.23f);
-
-            efx.AuxiliaryEffectSlot(slot, EfxAuxiliaryi.EffectslotEffect, effect);
-            efx.BindSourceToAuxiliarySlot(source, slot, 0, 0);
+            ALC.EFX.AuxiliaryEffectSlot(slot, EffectSlotInteger.Effect, effect);
+            ALC.EFX.Source(source, EFXSourceInteger3.AuxiliarySendFilter, slot, 0, 0);
         }
     }
 }

--- a/src/Audio/Effects/EffectTemplate.cs
+++ b/src/Audio/Effects/EffectTemplate.cs
@@ -1,19 +1,15 @@
-using OpenTK.Audio.OpenAL;
-
 namespace RPVoiceChat.Audio.Effects
 {
     public class EffectTemplate
     {
-        private EffectsExtension effectsExtension;
         private int source;
         public int filter;
 
         public bool IsEnabled { get; set; } = false;
 
-        public EffectTemplate(EffectsExtension effectsExtension, int source)
+        public EffectTemplate(int source)
         {
             this.source = source;
-            this.effectsExtension = effectsExtension;
             GenerateEffect();
         }
 

--- a/src/Audio/Effects/Filters/FilterLowpass.cs
+++ b/src/Audio/Effects/Filters/FilterLowpass.cs
@@ -4,7 +4,6 @@ namespace RPVoiceChat.Audio.Effects
 {
     public class FilterLowpass
     {
-        private EffectsExtension effectsExtension;
         private int source;
         private int nullFilter;
         public int filter;
@@ -12,11 +11,10 @@ namespace RPVoiceChat.Audio.Effects
         public bool IsEnabled { get; set; } = false;
 
 
-        public FilterLowpass(EffectsExtension effectsExtension, int source)
+        public FilterLowpass(int source)
         {
-            this.effectsExtension = effectsExtension;
             this.source = source;
-            nullFilter = effectsExtension.GenFilter();
+            nullFilter = ALC.EFX.GenFilter();
             GenerateFilter();
         }
 
@@ -27,12 +25,12 @@ namespace RPVoiceChat.Audio.Effects
         /// <param name="gain">The gain from 0.0 to 1.0.</param>
         public void SetHFGain(float gain)
         {
-            effectsExtension.Filter(filter, EfxFilterf.LowpassGainHF, gain);
+            ALC.EFX.Filter(filter, FilterFloat.LowpassGainHF, gain);
         }
 
         public void SetGain(float gain)
         {
-            effectsExtension.Filter(filter, EfxFilterf.LowpassGain, gain);
+            ALC.EFX.Filter(filter, FilterFloat.LowpassGain, gain);
         }
 
         public void Start()
@@ -40,7 +38,7 @@ namespace RPVoiceChat.Audio.Effects
             if (IsEnabled)
                 return;
 
-            effectsExtension.BindFilterToSource(source, filter);
+            AL.Source(source, ALSourcei.EfxDirectFilter, filter);
             IsEnabled = true;
         }
 
@@ -49,16 +47,16 @@ namespace RPVoiceChat.Audio.Effects
             if (!IsEnabled)
                 return;
 
-            effectsExtension.BindFilterToSource(source, nullFilter);
+            AL.Source(source, ALSourcei.EfxDirectFilter, nullFilter);
             IsEnabled = false;
         }
 
         private void GenerateFilter()
         {
-            filter = effectsExtension.GenFilter();
-            effectsExtension.Filter(filter, EfxFilteri.FilterType, (int)EfxFilterType.Lowpass);
-            effectsExtension.Filter(filter, EfxFilterf.LowpassGain, 1.0f);
-            effectsExtension.Filter(filter, EfxFilterf.LowpassGainHF, 0.2f);
+            filter = ALC.EFX.GenFilter();
+            ALC.EFX.Filter(filter, FilterInteger.FilterType, (int)FilterType.Lowpass);
+            ALC.EFX.Filter(filter, FilterFloat.LowpassGain, 1.0f);
+            ALC.EFX.Filter(filter, FilterFloat.LowpassGainHF, 0.2f);
         }
 
     }

--- a/src/Audio/Input/IAudioCapture.cs
+++ b/src/Audio/Input/IAudioCapture.cs
@@ -1,5 +1,6 @@
 using OpenTK.Audio.OpenAL;
 using System;
+using System.Collections.Generic;
 
 namespace RPVoiceChat.Audio
 {
@@ -7,9 +8,11 @@ namespace RPVoiceChat.Audio
     {
         public int AvailableSamples { get; }
         public string CurrentDevice { get; }
+        public static string DefaultDevice { get; }
         public ALFormat SampleFormat { get; }
         public void Start();
         public void Stop();
         public void ReadSamples(byte[] buffer, int count);
+        public static abstract List<string> GetAvailableDevices();
     }
 }

--- a/src/Audio/Input/MicrophoneManager.cs
+++ b/src/Audio/Input/MicrophoneManager.cs
@@ -250,6 +250,7 @@ namespace RPVoiceChat.Audio
             {
                 newCapture = new OpenALAudioCapture(deviceName, Frequency, format, BufferSize);
                 format = newCapture?.SampleFormat ?? format;
+                deviceName = newCapture?.CurrentDevice ?? deviceName;
                 Logger.client.Debug($"Succesfully created an audio capture device with arguments: {deviceName}, {Frequency}, {format}, {BufferSize}");
             }
             catch (Exception e)

--- a/src/Audio/Input/OpenALAudioCapture.cs
+++ b/src/Audio/Input/OpenALAudioCapture.cs
@@ -32,10 +32,7 @@ namespace RPVoiceChat.Audio
 
             string[] deviceNames = new string[] { deviceName, null, DefaultDevice };
             ALFormat[] formats = new ALFormat[] { captureFormat, ALFormat.Stereo16, ALFormat.Mono16 };
-
-            foreach (var device in deviceNames)
-                foreach (var format in formats)
-                    if (TryOpenDevice(device, format)) break;
+            TryOpenDevice(deviceNames, formats);
 
             if (_captureDevice == IntPtr.Zero)
                 throw new Exception("All attempts to open capture devices returned IntPtr.Zero");
@@ -66,6 +63,13 @@ namespace RPVoiceChat.Audio
             var devices = ALC.GetString(ALDevice.Null, AlcGetStringList.CaptureDeviceSpecifier);
 
             return devices;
+        }
+
+        private void TryOpenDevice(string[] deviceNames, ALFormat[] formats)
+        {
+            foreach (var device in deviceNames)
+                foreach (var format in formats)
+                    if (TryOpenDevice(device, format)) return;
         }
 
         private bool TryOpenDevice(string deviceName, ALFormat format)

--- a/src/Audio/Input/OpenALAudioCapture.cs
+++ b/src/Audio/Input/OpenALAudioCapture.cs
@@ -1,59 +1,113 @@
-using OpenTK.Audio;
 using OpenTK.Audio.OpenAL;
 using RPVoiceChat.Utils;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace RPVoiceChat.Audio
 {
     public class OpenALAudioCapture : IAudioCapture
     {
-        public int AvailableSamples { get { return audioCapture.AvailableSamples; } }
-        public string CurrentDevice { get { return audioCapture.CurrentDevice; } }
-        public ALFormat SampleFormat { get { return audioCapture.SampleFormat; } }
-        private AudioCapture audioCapture;
+        public int AvailableSamples
+        {
+            get
+            {
+                ALC.GetInteger(_captureDevice, AlcGetInteger.CaptureSamples, 1, out int result);
+                return result;
+            }
+        }
+        public string CurrentDevice { get; private set; }
+        public int Frequency { get; }
+        public ALFormat SampleFormat { get; private set; }
+        public int BufferSize { get; }
+        public static string DefaultDevice = ALC.GetString(ALDevice.Null, AlcGetString.CaptureDefaultDeviceSpecifier);
+        private ALCaptureDevice _captureDevice;
+        private bool IsDisposed = false;
+        private bool IsRunning = false;
 
-        public OpenALAudioCapture(string deviceName, int frequency, ALFormat format, int bufferSize)
+        public OpenALAudioCapture(string deviceName, int frequency, ALFormat captureFormat, int bufferSize)
         {
             if (deviceName == "Default") deviceName = null;
+            Frequency = frequency;
+            BufferSize = bufferSize;
 
-            try
-            {
-                audioCapture = new AudioCapture(deviceName, frequency, format, bufferSize);
-                return;
-            }
-            catch (Exception e)
-            {
-                Logger.client.VerboseDebug($"[Internal] Failed to open capture device {deviceName}, {frequency}, {format}, {bufferSize}: {e}");
-            }
+            string[] deviceNames = new string[] { deviceName, null, DefaultDevice };
+            ALFormat[] formats = new ALFormat[] { captureFormat, ALFormat.Stereo16, ALFormat.Mono16 };
 
-            audioCapture = new AudioCapture(deviceName, frequency, ALFormat.Mono16, bufferSize);
+            foreach (var device in deviceNames)
+                foreach (var format in formats)
+                    if (TryOpenDevice(device, format)) break;
+
+            if (_captureDevice == IntPtr.Zero)
+                throw new Exception("All attempts to open capture devices returned IntPtr.Zero");
+
+            if (CheckError(_captureDevice))
+                throw new Exception("Capture device returned an exception");
         }
 
         public void Start()
         {
-            audioCapture.Start();
+            ALC.CaptureStart(_captureDevice);
+            IsRunning = true;
         }
 
         public void Stop()
         {
-            audioCapture.Stop();
+            ALC.CaptureStop(_captureDevice);
+            IsRunning = false;
         }
 
         public void ReadSamples(byte[] buffer, int count)
         {
-            audioCapture.ReadSamples(buffer, count);
+            ALC.CaptureSamples(_captureDevice, buffer, count);
         }
 
         public static List<string> GetAvailableDevices()
         {
-            return AudioCapture.AvailableDevices.ToList();
+            var devices = ALC.GetString(ALDevice.Null, AlcGetStringList.CaptureDeviceSpecifier);
+
+            return devices;
+        }
+
+        private bool TryOpenDevice(string deviceName, ALFormat format)
+        {
+            CurrentDevice = deviceName;
+            SampleFormat = format;
+            _captureDevice = ALC.CaptureOpenDevice(deviceName, Frequency, format, BufferSize);
+            LogError();
+            return _captureDevice != IntPtr.Zero;
+        }
+
+        private void LogError()
+        {
+            CheckError(ALCaptureDevice.Null);
+        }
+
+        private bool CheckError(ALCaptureDevice device)
+        {
+            var ALCError = ALC.GetError(new ALDevice(device));
+            if (ALCError == AlcError.NoError) return false;
+
+            Logger.client.VerboseDebug($"[Internal] Failed to open capture device: {ALCError}, {CurrentDevice ?? "Default"}, {Frequency}, {SampleFormat}, {BufferSize}");
+            return true;
         }
 
         public void Dispose()
         {
-            audioCapture?.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public void Dispose(bool manual)
+        {
+            if (IsDisposed) return;
+
+            if (_captureDevice != IntPtr.Zero)
+            {
+                if (IsRunning) Stop();
+
+                ALC.CaptureCloseDevice(_captureDevice);
+            }
+            IsDisposed = true;
         }
     }
 }

--- a/src/Audio/OpenALWrapper.cs
+++ b/src/Audio/OpenALWrapper.cs
@@ -92,7 +92,7 @@ namespace RPVoiceChat.Audio
 
         public static void BufferData(int currentBuffer, ALFormat format, byte[] audio, int frequency)
         {
-            AL.BufferData(currentBuffer, format, audio, audio.Length, frequency);
+            AL.BufferData(currentBuffer, format, audio, frequency);
             CheckError("Error buffer data");
         }
 

--- a/src/Audio/Output/AudioOutputManager.cs
+++ b/src/Audio/Output/AudioOutputManager.cs
@@ -1,4 +1,3 @@
-using OpenTK.Audio.OpenAL;
 using RPVoiceChat.DB;
 using RPVoiceChat.Networking;
 using RPVoiceChat.Utils;
@@ -35,7 +34,6 @@ namespace RPVoiceChat.Audio
             }
         }
 
-        private EffectsExtension effectsExtension;
         private ConcurrentDictionary<string, PlayerAudioSource> playerSources = new ConcurrentDictionary<string, PlayerAudioSource>();
         private PlayerAudioSource localPlayerAudioSource;
         private ClientSettingsRepository clientSettingsRepo;
@@ -44,7 +42,6 @@ namespace RPVoiceChat.Audio
         {
             IsLoopbackEnabled = ClientSettings.Loopback;
             capi = api;
-            effectsExtension = new EffectsExtension();
             clientSettingsRepo = settingsRepository;
         }
 
@@ -98,7 +95,7 @@ namespace RPVoiceChat.Audio
 
         private void ClientLoaded()
         {
-            localPlayerAudioSource = new PlayerAudioSource(capi.World.Player, capi, clientSettingsRepo, effectsExtension)
+            localPlayerAudioSource = new PlayerAudioSource(capi.World.Player, capi, clientSettingsRepo)
             {
                 IsLocational = false,
             };
@@ -121,7 +118,7 @@ namespace RPVoiceChat.Audio
 
         private PlayerAudioSource CreatePlayerSource(IPlayer player)
         {
-            var source = new PlayerAudioSource(player, capi, clientSettingsRepo, effectsExtension);
+            var source = new PlayerAudioSource(player, capi, clientSettingsRepo);
             playerSources.AddOrUpdate(player.PlayerUID, source, (_, __) => source);
             source.StartPlaying();
 

--- a/src/Audio/Output/PlayerAudioSource.cs
+++ b/src/Audio/Output/PlayerAudioSource.cs
@@ -27,7 +27,6 @@ namespace RPVoiceChat.Audio
         private long lastAudioSequenceNumber = -1;
         private IAudioCodec codec;
         private FilterLowpass lowpassFilter;
-        private EffectsExtension effectsExtension;
 
         private ICoreClientAPI capi;
         private IPlayer player;
@@ -44,9 +43,8 @@ namespace RPVoiceChat.Audio
         private Vec3f lastSpeakerCoords;
         private DateTime? lastSpeakerUpdate;
 
-        public PlayerAudioSource(IPlayer player, ICoreClientAPI capi, ClientSettingsRepository clientSettingsRepo, EffectsExtension effectsExtension)
+        public PlayerAudioSource(IPlayer player, ICoreClientAPI capi, ClientSettingsRepository clientSettingsRepo)
         {
-            this.effectsExtension = effectsExtension;
             this.player = player;
             this.capi = capi;
             this.clientSettingsRepo = clientSettingsRepo;
@@ -106,7 +104,7 @@ namespace RPVoiceChat.Audio
             lowpassFilter?.Stop();
             if (mufflingEnabled && wallThickness != 0)
             {
-                lowpassFilter = lowpassFilter ?? new FilterLowpass(effectsExtension, source);
+                lowpassFilter = lowpassFilter ?? new FilterLowpass(source);
                 lowpassFilter.Start();
                 lowpassFilter.SetHFGain(Math.Max(1.0f - (wallThickness / 2), 0.1f));
             }
@@ -211,11 +209,7 @@ namespace RPVoiceChat.Audio
         {
             lock (ordering_queue_lock)
             {
-                if (orderingQueue.ContainsKey(sequenceNumber))
-                {
-                    Logger.client.VerboseDebug($"Audio sequence {sequenceNumber} already received, skipping enqueueing");
-                    return;
-                }
+                if (orderingQueue.ContainsKey(sequenceNumber)) return;
 
                 if (lastAudioSequenceNumber >= sequenceNumber)
                 {

--- a/src/Client/PlayerNetworkClient.cs
+++ b/src/Client/PlayerNetworkClient.cs
@@ -77,7 +77,6 @@ namespace RPVoiceChat.Client
             }
             isConnected = true;
 
-            if (activeTransports[0] is NativeNetworkClient) api.Event.EnqueueMainThreadTask(() => api.ShowChatMessage($"<strong>[RPVoiceChat]: Failed to connect with custom network clients, audio stability will be degraded</strong>"), "rpvoicechat:PlayerNetworkClient");
             if (activeTransports.Count > 0) return;
             IEnumerable<string> serverTransportIDs = serverConnections.Select(e => e.Transport);
             throw new Exception($"Failed to connect to the server. Supported transports: {string.Join(", ", serverTransportIDs)}");
@@ -123,7 +122,6 @@ namespace RPVoiceChat.Client
             if (isShutdown) return;
             activeTransports.Remove(transport);
             transport.Dispose();
-            api.Event.EnqueueMainThreadTask(() => api.ShowChatMessage($"<strong>[RPVoiceChat]: Failed to reconnect with {transportID} client, audio stability will be degraded</strong>"), "rpvoicechat:PlayerNetworkClient");
         }
 
         private bool Reconnect(IExtendedNetworkClient transport)

--- a/src/Config/RPVoiceChatConfig.cs
+++ b/src/Config/RPVoiceChatConfig.cs
@@ -19,6 +19,7 @@ namespace RPVoiceChat
         public int ServerPort = 52525;
         public string ServerIP = null;
         public bool AdditionalContent = true;
+        public bool UseCustomNetworkServers = false;
 
         // --- Client Settings ---
         // These are meant to be set by the client, but are
@@ -43,6 +44,7 @@ namespace RPVoiceChat
             ServerPort = previousConfig.ServerPort;
             ServerIP = previousConfig.ServerIP;
             AdditionalContent = previousConfig.AdditionalContent;
+            UseCustomNetworkServers = previousConfig.UseCustomNetworkServers;
 
             PushToTalkEnabled = previousConfig.PushToTalkEnabled;
             IsMuted = previousConfig.IsMuted;

--- a/src/Gui/CustomElements/AudioMeter.cs
+++ b/src/Gui/CustomElements/AudioMeter.cs
@@ -31,8 +31,6 @@ namespace RPVoiceChat.Gui
             Bounds = bounds.FlatCopy().WithFixedWidth(audioMeterWidth);
         }
 
-        public void OnAdd(GuiComposer composer) { }
-
         private void SetCoefficient()
         {
             coefficient = 100;

--- a/src/Gui/CustomElements/IExtendedGuiElement.cs
+++ b/src/Gui/CustomElements/IExtendedGuiElement.cs
@@ -5,6 +5,6 @@ namespace RPVoiceChat.Gui
     public interface IExtendedGuiElement
     {
         public void Init(string elementKey, ElementBounds bounds, GuiComposer composer);
-        public void OnAdd(GuiComposer composer);
+        public void OnAdd(GuiComposer composer) { }
     }
 }

--- a/src/Gui/CustomElements/PlayerList.cs
+++ b/src/Gui/CustomElements/PlayerList.cs
@@ -113,7 +113,7 @@ namespace RPVoiceChat.Gui
 
         private bool SlidePlayerVolume(int gain, string sliderKey)
         {
-            string playerId = sliderKey.Split('_')[0];
+            string playerId = sliderKey.Split("_")[0];
             settingsRepository.SetPlayerGain(playerId, gain);
 
             return true;

--- a/src/Gui/ModMenuDialog.cs
+++ b/src/Gui/ModMenuDialog.cs
@@ -425,6 +425,7 @@ namespace RPVoiceChat.Gui
         private void OnChangeInputDevice(string value, bool selected)
         {
             audioInputManager.SetInputDevice(value);
+            SetValue("inputDevice", ClientSettings.CurrentInputDevice ?? "Default");
         }
 
         private void OnTogglePushToTalk(bool enabled)

--- a/src/Networking/IExtendedNetworkServer.cs
+++ b/src/Networking/IExtendedNetworkServer.cs
@@ -2,7 +2,6 @@ namespace RPVoiceChat.Networking
 {
     public interface IExtendedNetworkServer : INetworkServer
     {
-        public void Launch();
         public void PlayerConnected(string playerId, ConnectionInfo connectionInfo);
         public void PlayerDisconnected(string playerId);
     }

--- a/src/Networking/INetworkServer.cs
+++ b/src/Networking/INetworkServer.cs
@@ -6,6 +6,7 @@ namespace RPVoiceChat.Networking
     {
         public event Action<AudioPacket> AudioPacketReceived;
 
+        public void Launch();
         public ConnectionInfo GetConnectionInfo();
         public string GetTransportID();
         public bool SendPacket(NetworkPacket packet, string playerId);

--- a/src/Networking/NativeNetwork/NativeNetworkBase.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkBase.cs
@@ -5,6 +5,7 @@ namespace RPVoiceChat.Networking
     public abstract class NativeNetworkBase
     {
         protected const string ChannelName = "RPAudioChannel";
+        protected const string SPChannelName = $"{ChannelName}_SP";
         protected const string _transportID = "NativeTCP";
 
         public NativeNetworkBase(ICoreAPI api)
@@ -15,11 +16,6 @@ namespace RPVoiceChat.Networking
         public string GetTransportID()
         {
             return _transportID;
-        }
-
-        public void Dispose()
-        {
-            // Game handles disposal for us
         }
     }
 }

--- a/src/Networking/NativeNetwork/NativeNetworkClient.cs
+++ b/src/Networking/NativeNetwork/NativeNetworkClient.cs
@@ -1,5 +1,8 @@
+using HarmonyLib;
 using System;
+using System.Reflection;
 using Vintagestory.API.Client;
+using Vintagestory.Client.NoObf;
 
 namespace RPVoiceChat.Networking
 {
@@ -7,21 +10,44 @@ namespace RPVoiceChat.Networking
     {
         public event Action<AudioPacket> OnAudioReceived;
         private IClientNetworkChannel channel;
+        private IClientNetworkChannel singleplayerChannel;
 
         public NativeNetworkClient(ICoreClientAPI api) : base(api)
         {
             channel = api.Network.GetChannel(ChannelName).SetMessageHandler<AudioPacket>(HandleAudioPacket);
+            if (api.IsSinglePlayer)
+                singleplayerChannel = api.Network.RegisterChannel(SPChannelName).RegisterMessageType<AudioPacket>();
+            SystemNetworkProcessPatch.OnProcessInBackground += ProcessInBackground;
         }
 
         public bool SendAudioToServer(AudioPacket packet)
         {
+            var channel = singleplayerChannel ?? this.channel;
             channel.SendPacket(packet);
+            return true;
+        }
+
+        private static FieldInfo channelIdField = AccessTools.Field(typeof(NetworkChannel), "channelId");
+
+        private bool ProcessInBackground(int channelId, Packet_CustomPacket customPacket)
+        {
+            if (channel is not NetworkChannel nativeChannel) return false;
+
+            var expectedChannelId = (int)channelIdField.GetValue(channel);
+            if (channelId != expectedChannelId) return false;
+
+            nativeChannel.OnPacket(customPacket);
             return true;
         }
 
         private void HandleAudioPacket(AudioPacket packet)
         {
             OnAudioReceived?.Invoke(packet);
+        }
+
+        public void Dispose()
+        {
+            SystemNetworkProcessPatch.OnProcessInBackground -= ProcessInBackground;
         }
     }
 }

--- a/src/Networking/Packets/ConnectionRequest.cs
+++ b/src/Networking/Packets/ConnectionRequest.cs
@@ -6,7 +6,7 @@ namespace RPVoiceChat.Networking
     [ProtoContract(ImplicitFields = ImplicitFields.AllPublic)]
     public class ConnectionRequest : NetworkPacket
     {
-        public ConnectionInfo[] SupportedTransports { get; set; }
+        public ConnectionInfo[] SupportedTransports { get; }
         protected override PacketType Code { get => PacketType.ConnectionRequest; }
 
         public ConnectionRequest() { }

--- a/src/Networking/Packets/NetworkPacket.cs
+++ b/src/Networking/Packets/NetworkPacket.cs
@@ -11,7 +11,7 @@ namespace RPVoiceChat.Networking
         public byte[] ToBytes()
         {
             var stream = new MemoryStream();
-            stream.Write(BitConverter.GetBytes((int)Code), 0, 4);
+            stream.Write(BitConverter.GetBytes((int)Code));
             Serializer.Serialize(stream, this);
             return stream.ToArray();
         }

--- a/src/Patches/NetworkAPI.cs
+++ b/src/Patches/NetworkAPI.cs
@@ -1,0 +1,34 @@
+using HarmonyLib;
+using System;
+using System.Reflection;
+using Vintagestory.Server;
+
+namespace RPVoiceChat
+{
+    /// <summary>
+    /// Patches <b>server's</b> NetworkAPI to allow skipping handling of packets over certain channels
+    /// </summary>
+    static class NetworkAPIPatch
+    {
+        public static event Func<int, bool> OnHandleCustomPacket;
+
+        public static void Patch(Harmony harmony)
+        {
+            var OriginalMethod = AccessTools.Method(typeof(NetworkAPI), nameof(HandleCustomPacket));
+            var PrefixMethod = AccessTools.Method(typeof(NetworkAPIPatch), nameof(HandleCustomPacket));
+            harmony.Patch(OriginalMethod, prefix: new HarmonyMethod(PrefixMethod));
+        }
+
+        private static FieldInfo CustomPacketField = AccessTools.Field(typeof(Packet_Client), "CustomPacket");
+        private static FieldInfo ChannelIdField = AccessTools.Field(typeof(Packet_CustomPacket), "ChannelId");
+
+        public static bool HandleCustomPacket(Packet_Client packet)
+        {
+            var customPacket = (Packet_CustomPacket)CustomPacketField.GetValue(packet);
+            var channelId = (int)ChannelIdField.GetValue(customPacket);
+            bool isAlreadyHandled = OnHandleCustomPacket?.Invoke(channelId) ?? false;
+            bool shouldHandle = !isAlreadyHandled;
+            return shouldHandle;
+        }
+    }
+}

--- a/src/Patches/PatchManager.cs
+++ b/src/Patches/PatchManager.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using System;
+using Vintagestory.API.Common;
 
 namespace RPVoiceChat
 {
@@ -12,12 +13,25 @@ namespace RPVoiceChat
             harmony = new Harmony(harmonyId);
         }
 
-        public void Patch()
+        public void Patch(ICoreAPI api)
+        {
+            if ((api.Side & EnumAppSide.Client) != 0) PatchClient();
+            if ((api.Side & EnumAppSide.Server) != 0) PatchServer();
+        }
+
+        private void PatchClient()
         {
             EntityNameTagRendererRegistryPatch.Patch(harmony);
             GuiDialogCreateCharacterPatch.Patch(harmony);
             GuiElementSliderPatch.Patch(harmony);
             LoadedSoundNativePatch.Patch(harmony);
+            SystemNetworkProcessPatch.Patch(harmony);
+        }
+
+        private void PatchServer()
+        {
+            NetworkAPIPatch.Patch(harmony);
+            TcpNetServerPatch.Patch(harmony);
         }
 
         public void Unpatch()

--- a/src/Patches/SystemNetworkProcess.cs
+++ b/src/Patches/SystemNetworkProcess.cs
@@ -1,0 +1,39 @@
+using HarmonyLib;
+using System;
+using System.Reflection;
+using Vintagestory.Client.NoObf;
+
+namespace RPVoiceChat
+{
+    /// <summary>
+    /// Allows TCP messages from custom channels received by client to be processed in separate thread
+    /// </summary>
+    static class SystemNetworkProcessPatch
+    {
+        public static event Func<int, Packet_CustomPacket, bool> OnProcessInBackground;
+
+        private const int _customPacketId = 55;
+
+        public static void Patch(Harmony harmony)
+        {
+            var OriginalMethod = AccessTools.Method(typeof(SystemNetworkProcess), nameof(ProcessInBackground));
+            var PostfixMethod = AccessTools.Method(typeof(SystemNetworkProcessPatch), nameof(ProcessInBackground));
+            harmony.Patch(OriginalMethod, postfix: new HarmonyMethod(PostfixMethod));
+        }
+
+        private static FieldInfo packetIdField = AccessTools.Field(typeof(Packet_Server), "Id");
+        private static FieldInfo customPacketField = AccessTools.Field(typeof(Packet_Server), "CustomPacket");
+        private static FieldInfo channelIdField = AccessTools.Field(typeof(Packet_CustomPacket), "ChannelId");
+
+        public static void ProcessInBackground(ref bool __result, Packet_Server packet)
+        {
+            var id = (int)packetIdField.GetValue(packet);
+            if (id != _customPacketId) return;
+
+            var customPacket = (Packet_CustomPacket)customPacketField.GetValue(packet);
+            var channelId = (int)channelIdField.GetValue(customPacket);
+            bool processed = OnProcessInBackground?.Invoke(channelId, customPacket) ?? false;
+            if (processed) __result = true;
+        }
+    }
+}

--- a/src/Patches/TcpNetServer.cs
+++ b/src/Patches/TcpNetServer.cs
@@ -1,0 +1,73 @@
+using HarmonyLib;
+using RPVoiceChat.Utils;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using Vintagestory.Common;
+using Vintagestory.Server;
+
+namespace RPVoiceChat
+{
+    /// <summary>
+    /// Copies TCP messages received by server into own message queue for further processing from separate thread
+    /// </summary>
+    static class TcpNetServerPatch
+    {
+        private static readonly CodeInstruction anchor = new CodeInstruction(
+            OpCodes.Callvirt,
+            AccessTools.Method(typeof(Queue<NetIncomingMessage>), "Enqueue")
+        );
+        private static readonly List<CodeInstruction> patch = new List<CodeInstruction>() {
+            // Pass first local variable (msg)
+            new CodeInstruction(OpCodes.Ldloc_0),
+            // Into OnReceivedMessage
+            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TcpNetServerPatch), nameof(OnReceivedMessage)))
+        };
+        private static Queue<NetIncomingMessage> messages = new Queue<NetIncomingMessage>();
+
+        public static void Patch(Harmony harmony)
+        {
+            var OriginalMethod = AccessTools.Method(typeof(TcpNetServer), "server_ReceivedMessage");
+            var TranspilerMethod = AccessTools.Method(typeof(TcpNetServerPatch), nameof(server_ReceivedMessage_Transpiler));
+            harmony.Patch(OriginalMethod, transpiler: new HarmonyMethod(TranspilerMethod));
+        }
+
+        public static IEnumerable<CodeInstruction> server_ReceivedMessage_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var patchIndex = -1;
+            var codes = new List<CodeInstruction>(instructions);
+            for (var i = 0; i < codes.Count; i++)
+            {
+                var codeInstr = codes[i];
+                if (codeInstr.opcode != anchor.opcode) continue;
+                if (codeInstr.operand != anchor.operand) continue;
+                patchIndex = i;
+                break;
+            }
+
+            if (patchIndex == -1)
+            {
+                Logger.server.Error("Couldn't find transpiler anchor for TcpNetServer patch");
+                return instructions;
+            }
+
+            codes.InsertRange(patchIndex, patch);
+            Logger.server.Notification("TcpNetServer was successfully patched");
+            return codes.AsEnumerable();
+        }
+
+        private static void OnReceivedMessage(NetIncomingMessage msg)
+        {
+            lock (messages) messages.Enqueue(msg);
+        }
+
+        public static NetIncomingMessage ReadMessage()
+        {
+            lock (messages)
+            {
+                if (messages.Count == 0) return null;
+                return messages.Dequeue();
+            }
+        }
+    }
+}

--- a/src/RPVoiceChatClient.cs
+++ b/src/RPVoiceChatClient.cs
@@ -16,7 +16,6 @@ namespace RPVoiceChat
         private ClientSettingsRepository clientSettingsRepository;
         private MicrophoneManager micManager;
         private AudioOutputManager audioOutputManager;
-        private PatchManager patchManager;
         private PlayerNetworkClient client;
 
         protected ICoreClientAPI capi;
@@ -44,11 +43,9 @@ namespace RPVoiceChat
             // Init data repositories
             clientSettingsRepository = new ClientSettingsRepository(capi.Logger);
 
-            // Init microphone, audio output and harmony patch managers
+            // Init microphone and audio output managers
             micManager = new MicrophoneManager(capi);
             audioOutputManager = new AudioOutputManager(capi, clientSettingsRepository);
-            patchManager = new PatchManager(modID);
-            patchManager.Patch();
 
             // Init voice chat client
             bool forwardPorts = !config.ManualPortForwarding;
@@ -155,7 +152,6 @@ namespace RPVoiceChat
             ClientSettings.Save();
             micManager?.Dispose();
             audioOutputManager?.Dispose();
-            patchManager?.Dispose();
             client?.Dispose();
             modMenuDialog?.Dispose();
             clientSettingsRepository?.Dispose();

--- a/src/RPVoiceChatMod.cs
+++ b/src/RPVoiceChatMod.cs
@@ -5,8 +5,9 @@ namespace RPVoiceChat
 {
     public abstract class RPVoiceChatMod : ModSystem
     {
-        protected RPVoiceChatConfig config;
         public static readonly string modID = "rpvoicechat";
+        protected RPVoiceChatConfig config;
+        private PatchManager patchManager;
 
         public override void StartPre(ICoreAPI api)
         {
@@ -19,8 +20,16 @@ namespace RPVoiceChat
 
         public override void Start(ICoreAPI api)
         {
+            patchManager = new PatchManager(modID);
+            patchManager.Patch(api);
+
             ItemRegistry.RegisterItems(api);
             BlockRegistry.RegisterBlocks(api);
+        }
+
+        public override void Dispose()
+        {
+            patchManager?.Dispose();
         }
     }
 }

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -14,7 +14,6 @@ namespace RPVoiceChat.Server
         private IServerNetworkChannel handshakeChannel;
         private Dictionary<string, INetworkServer> serverByTransportID = new Dictionary<string, INetworkServer>();
         private ConnectionRequest connectionRequest;
-        private bool ToggledOff = false;
 
         public GameServer(ICoreServerAPI sapi, List<INetworkServer> serverTransports)
         {
@@ -52,8 +51,6 @@ namespace RPVoiceChat.Server
 
         public void SendAudioToAllClientsInRange(AudioPacket packet)
         {
-            if (ToggledOff) return;
-
             var transmittingPlayer = api.World.PlayerByUid(packet.PlayerId);
             int distance = WorldConfig.GetInt(packet.VoiceLevel);
             int squareDistance = distance * distance;
@@ -92,9 +89,7 @@ namespace RPVoiceChat.Server
         {
             var transportID = server.GetTransportID();
             Logger.server.Notification($"Launching {transportID} server");
-            if (server is IExtendedNetworkServer extendedServer)
-                extendedServer?.Launch();
-
+            server.Launch();
             activeServers.Add(server);
             serverByTransportID.Add(transportID, server);
             Logger.server.Notification($"{transportID} server started");
@@ -158,17 +153,6 @@ namespace RPVoiceChat.Server
             connectionRequest = new ConnectionRequest(serverConnectionInfos);
 
             return connectionRequest;
-        }
-
-        public bool ServerToggle(bool b)
-        {
-            if (b != ToggledOff)
-            {
-                ToggledOff = b;
-                return true;
-            }
-
-            return false;
         }
 
         public void Dispose()

--- a/src/Utils/AudioUtils.cs
+++ b/src/Utils/AudioUtils.cs
@@ -7,15 +7,14 @@ namespace RPVoiceChat.Utils
     {
         public static int ChannelsPerFormat(ALFormat format)
         {
-            switch (format)
-            {
-                case ALFormat.Mono16:
-                    return 1;
-                case ALFormat.MultiQuad16Ext:
-                    return 4;
-                default:
-                    throw new NotSupportedException($"Format {format} is not supported for capture");
-            }
+            int channels = format switch {
+                ALFormat.Mono16 => 1,
+                ALFormat.Stereo16 => 2,
+                ALFormat.MultiQuad16Ext => 4,
+                _ => throw new NotSupportedException($"Format {format} is not supported for capture")
+            };
+
+            return channels;
         }
 
         public static byte[] ShortsToBytes(short[] audio, int offset, int length)

--- a/src/Utils/EmbeddedDllLoader.cs
+++ b/src/Utils/EmbeddedDllLoader.cs
@@ -42,7 +42,7 @@ namespace RPVoiceChat.Utils
             string dirName = Path.Combine(Path.GetTempPath(), tempFolder);
             if (!Directory.Exists(dirName)) Directory.CreateDirectory(dirName);
 
-            string[] resourceNameParts = resourceName.Split('.');
+            string[] resourceNameParts = resourceName.Split(".");
             string dllName = $"{resourceNameParts[resourceNameParts.Length - 2]}.{resourceNameParts[resourceNameParts.Length - 1]}";
             string dllPath = Path.Combine(dirName, dllName);
             bool alreadyExtracted = false;

--- a/src/Utils/NetworkUtils.cs
+++ b/src/Utils/NetworkUtils.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 
 namespace RPVoiceChat.Utils
 {
@@ -71,7 +72,7 @@ namespace RPVoiceChat.Utils
 
         public static string GetPublicIP()
         {
-            string publicIPString = new WebClient().DownloadString("https://ipinfo.io/ip");
+            string publicIPString = new HttpClient().GetStringAsync("https://ipinfo.io/ip").GetAwaiter().GetResult();
 
             return publicIPString;
         }


### PR DESCRIPTION
**This PR is based on #115, make sure to merge it before this PR** 

Fixes mod always using default device because of break statement in nested loop
Makes mod menu immediately update used input device after selection in case default input device was used instead of the one selected by user
Bumps patch version