### PR TITLE
Fix server crash caused by multi-threading

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -5,5 +5,5 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
     "description": "A mod that adds in game voice proximity chat!",
-    "version": "2.3.6"
+    "version": "2.3.7"
 }

--- a/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
+++ b/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
@@ -54,7 +54,7 @@ namespace RPVoiceChat.Networking
                     }
                     Thread.Sleep(1);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     Logger.server.Error($"Caught exception outside of main thread! Proceeding to ignore it to avoid server crash:\n{e}");
                 }
@@ -100,7 +100,7 @@ namespace RPVoiceChat.Networking
                         return (IServerPlayer)PlayerField.GetValue(connectedClient);
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 // ServerMain.Clients is a regular Dictionary that can get modified from the main thread, causing "Collection was modified" exception
                 // It is a public object with no mechanisms for synchronization so there is nothing we can really do from our side to prevent this.

--- a/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
+++ b/src/Networking/NativeNetwork/ServerSystemNetworkProcess.cs
@@ -40,17 +40,24 @@ namespace RPVoiceChat.Networking
             var ct = (CancellationToken)cancellationToken;
             while (packetProcessingThread.IsAlive && !ct.IsCancellationRequested)
             {
-                NetIncomingMessage msg;
-                while ((msg = TcpNetServerPatch.ReadMessage()) != null)
+                try
                 {
-                    var connection = (NetConnection)senderConnectionField.GetValue(msg);
-                    var player = ResolveServerPlayer(connection);
-                    if (player == null) continue;
-                    var data = (byte[])messageField.GetValue(msg);
-                    var length = (int)messageLengthField.GetValue(msg);
-                    TryReadPacket(data, length, player);
+                    NetIncomingMessage msg;
+                    while ((msg = TcpNetServerPatch.ReadMessage()) != null)
+                    {
+                        var connection = (NetConnection)senderConnectionField.GetValue(msg);
+                        var player = ResolveServerPlayer(connection);
+                        if (player == null) continue;
+                        var data = (byte[])messageField.GetValue(msg);
+                        var length = (int)messageLengthField.GetValue(msg);
+                        TryReadPacket(data, length, player);
+                    }
+                    Thread.Sleep(1);
                 }
-                Thread.Sleep(1);
+                catch(Exception e)
+                {
+                    Logger.server.Error($"Caught exception outside of main thread! Proceeding to ignore it to avoid server crash:\n{e}");
+                }
             }
         }
 

--- a/src/Networking/TCPNetwork/TCPNetworkServer.cs
+++ b/src/Networking/TCPNetwork/TCPNetworkServer.cs
@@ -102,13 +102,14 @@ namespace RPVoiceChat.Networking
 
                     ConnectionAccepted(connectionSocket);
                 }
-                catch (SocketException e)
+                catch (Exception e)
                 {
-                    if (e.SocketErrorCode == SocketError.Interrupted ||
-                        e.SocketErrorCode == SocketError.OperationAborted ||
+                    if (e is SocketException se &&
+                        (se.SocketErrorCode == SocketError.Interrupted ||
+                        se.SocketErrorCode == SocketError.OperationAborted) ||
                         ct.IsCancellationRequested) return;
 
-                    throw;
+                    logger.Error($"Caught exception outside of main thread! Proceeding to ignore it to avoid server crash:\n{e}");
                 }
             }
         }


### PR DESCRIPTION
Fixes a rare server crash when a client joins precisely when `ServerSystemNetworkProcess` tries to resolve `NetConnection` into `IServerPlayer`.
Wraps server threads in `try..catch` to ensure that the mod never crashes the server. This may result in unstable behavior of the mod if an exception is unrecoverable, but that shouldn't happen in the first place and is better than potential loss of progress. 