### PR TITLE
Fix TcpNetServer changes for 1.20.6

### DIFF
--- a/src/Patches/TcpNetServer.cs
+++ b/src/Patches/TcpNetServer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using HarmonyLib;
 using RPVoiceChat.Utils;
 using System.Collections.Generic;
@@ -15,7 +16,7 @@ namespace RPVoiceChat
     {
         private static readonly CodeInstruction anchor = new CodeInstruction(
             OpCodes.Callvirt,
-            AccessTools.Method(typeof(Queue<NetIncomingMessage>), "Enqueue")
+            AccessTools.Method(typeof(ConcurrentQueue<NetIncomingMessage>), "Enqueue")
         );
         private static readonly List<CodeInstruction> patch = new List<CodeInstruction>() {
             // Pass first local variable (msg)


### PR DESCRIPTION
TcpNetServer changed a little in 1.20.5 so the patch wasn't applying anymore, I updated the anchor so that it works again.