### PR TITLE
Fixed #193 introduced by 1.20.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,9 @@ _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
 
+# Jetbrains Rider files
+*.idea
+
 # TeamCity is a build add-in
 _TeamCity*
 

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,11 +5,11 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie", "RomainOdeval" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash"],
     "description": "A mod that adds in game voice proximity chat! Also bunch of in-game communication tools!",
-    "version": "2.3.18",
+    "version": "2.3.19",
     "Side": "Universal",
     "RequiredOnClient": true,
     "RequiredOnServer": true,
     "dependencies": {
-        "game": "1.20.10"
+        "game": "1.20.11"
     }
 }


### PR DESCRIPTION
## Problem
When 1.20.11 was released it modified _VintageStory.Server.ServerMain.Clients_ which caused the console to be flooded by errors.
## Solution
A recomp targeting 1.20.11 will fix the error, but in order to push an update I updated _modinfo.json_.