### PR TITLE
Create and apply  an intoxicated effect when a player is drunk

### DIFF
--- a/assets/rpvoicechat/lang/en.json
+++ b/assets/rpvoicechat/lang/en.json
@@ -91,6 +91,8 @@
   "Command.WallThicknessWeighting.Desc": "Set a value that weighting the wall thickness calculated for muffling",
   "Command.WallThicknessWeighting.Help": "Wall thickness is divided by this weighting to remove gain at the high-frequency limit of the filter, simuling muffling. Values below 1 will increase muffling effect, values upper 1 will reduced it. Default value is <strong>1.5f</strong>",
   "Command.WallThicknessWeighting.Success": "Wall thickness weighting set to {0}",
+  "Command.IntoxicatedEffect.Desc": "Toggles intoxicated effect. See help for more info",
+  "Command.IntoxicatedEffect.Help": "Apply an intoxicated effect on a player's voice when drunk.'",
 
   "Hotkey.ModMenu": "RPVoice: Mod menu",
   "Hotkey.VoiceLevel": "RPVoice: Change voice distance",

--- a/assets/rpvoicechat/lang/fr.json
+++ b/assets/rpvoicechat/lang/fr.json
@@ -85,6 +85,8 @@
   "Command.WallThicknessWeighting.Desc": "Définissez une valeur qui pondère l'épaisseur de paroi calculée pour l'atténuation",
   "Command.WallThicknessWeighting.Help": "L'épaisseur de la paroi est divisée par cette pondération pour supprimer le gain à la limite haute de fréquence du filtre, simulant ainsi l'étouffement. Les valeurs inférieures à 1 augmenteront l'effet d'étouffement, les valeurs supérieures à 1 le réduiront. La valeur par défaut est <strong>1,5f</strong>",
   "Command.WallThicknessWeighting.Success": "Pondération de l'épaisseur de paroi définie à {0}",
+  "Command.IntoxicatedEffect.Desc": "Active/désactive l'effet d'intoxication. Voir l'aide pour plus d'informations",
+  "Command.IntoxicatedEffect.Help": "Applique un effet d'intoxication sur la voix d'un joueur quand ce dernier est ivre.",
   "Hotkey.ModMenu": "RPVoice: menu du mod",
   "Hotkey.VoiceLevel": "RPVoice : Changer la distance vocale",
   "Hotkey.PTT": "RPVoice: Push-to-talk",

--- a/src/Audio/Effects/IntoxicatedEffect.cs
+++ b/src/Audio/Effects/IntoxicatedEffect.cs
@@ -7,16 +7,27 @@ namespace RPVoiceChat.Audio.Effects
     {
         protected float toxicRate;
 
-        public IntoxicatedEffect(int source) : base(source) {}
+        public IntoxicatedEffect(int source) : base(source) { }
 
         protected override int GenerateEffect()
         {
-            // WARNING : changing pitch also changes audio playback speed, causing overflow of circular audio buffer.
-            // More advanced implementation is required before using this effect
-            float pitch = toxicRate <= 0.2 ? 1 : 1 - (toxicRate / 5);
-            OALW.Source(source, ALSourcef.Pitch, pitch);
+            int effect = ALC.EFX.GenEffect();
 
-            throw new NotImplementedException();
+            ALC.EFX.Effect(effect, EffectInteger.EffectType, 5);
+
+            // Adjust pitch according to toxicRate (more toxic = greater shift)
+            // CoarseTune = semitones, FineTune = cents
+            float coarseTune = (toxicRate - 0.5f) * 12f;  // roughly from -6 to +6 semitones
+            float fineTune = (toxicRate - 0.5f) * 100f;   // roughly from -50 to +50 cents
+
+            ALC.EFX.Effect(effect, EffectInteger.PitchShifterCoarseTune, (int)coarseTune);
+            ALC.EFX.Effect(effect, EffectInteger.PitchShifterFineTune, (int)fineTune);
+
+            slot = ALC.EFX.GenAuxiliaryEffectSlot();
+            ALC.EFX.AuxiliaryEffectSlot(slot, EffectSlotInteger.Effect, effect);
+
+            this.effect = effect;
+            return effect;
         }
 
         public void SetToxicRate(float toxicRate)

--- a/src/Audio/Output/PlayerAudioSource.cs
+++ b/src/Audio/Output/PlayerAudioSource.cs
@@ -101,7 +101,7 @@ namespace RPVoiceChat.Audio
             // If the player is on the other side of something to the listener, then the player's voice should be muffled
             bool mufflingEnabled = ClientSettings.Muffling;
             float wallThickness = LocationUtils.GetWallThickness(capi, player, capi.World.Player);
-            float wallThicknessWeighting = WorldConfig.GetFloat("wallThicknessWeighting");
+            float wallThicknessWeighting = WorldConfig.GetFloat("wall-thickness-weighting");
             if (capi.World.Player.Entity.Swimming)
                 wallThickness += 1.0f;
 
@@ -133,12 +133,11 @@ namespace RPVoiceChat.Audio
                 unstableEffect.Apply();
             }
 
-            // DEACTIVATED : TO BE IMPLEMENTED
             // If the player is drunk, then the player's voice should be affected
-            // Values are temporary currently
             intoxicatedEffect?.Clear();
+            bool intoxicatedEffectToggle = WorldConfig.GetBool("intoxicated-effect");
             float drunkness = player.Entity.WatchedAttributes.GetFloat("intoxication");
-            if (toBeImplementedToggle && drunkness > 0)
+            if (intoxicatedEffectToggle && drunkness > 0)
             {
                 intoxicatedEffect = intoxicatedEffect ?? new IntoxicatedEffect(source);
                 intoxicatedEffect.SetToxicRate(drunkness);

--- a/src/RPVoiceChatServer.cs
+++ b/src/RPVoiceChatServer.cs
@@ -1,9 +1,10 @@
+using System;
+using System.Collections.Generic;
+using RPVoiceChat.Audio.Effects;
 using RPVoiceChat.Networking;
 using RPVoiceChat.Server;
 using RPVoiceChat.Systems;
 using RPVoiceChat.Utils;
-using System;
-using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.CommandAbbr;
 using Vintagestory.API.Server;
@@ -26,6 +27,7 @@ namespace RPVoiceChat
             WorldConfig.Set("encode-audio", WorldConfig.GetBool("encode-audio", true));
             WorldConfig.Set("others-hear-spectators", WorldConfig.GetBool("others-hear-spectators", true));
             WorldConfig.Set("wall-thickness-weighting", WorldConfig.GetFloat("wall-thickness-weighting", 2));
+            WorldConfig.Set("intoxicated-effect", WorldConfig.GetBool("intoxicated-effect", true));
 
             // Register commands
             registerCommands();
@@ -114,6 +116,12 @@ namespace RPVoiceChat
                     .WithAdditionalInformation(UIUtils.I18n("Command.WallThicknessWeighting.Help"))
                     .WithArgs(parsers.Float("weighting"))
                     .HandleWith(SetWallThicknessWeighting)
+                .EndSub()
+                .BeginSub("intoxicated")
+                    .WithDesc(UIUtils.I18n("Command.IntoxicatedEffect.Desc"))
+                    .WithAdditionalInformation(UIUtils.I18n("Command.IntoxicatedEffect.Help"))
+                    .WithArgs(parsers.Bool("state"))
+                    .HandleWith(ToggleIntoxicatedEffect)
                 .EndSub();
         }
 
@@ -167,8 +175,9 @@ namespace RPVoiceChat
             bool forceNameTags = WorldConfig.GetBool("force-render-name-tags");
             bool encoding = WorldConfig.GetBool("encode-audio");
             float wallThicknessWeighting = WorldConfig.GetFloat("wall-thickness-weighting");
+            bool intoxicatedEffect = WorldConfig.GetBool("intoxicated-effect");
 
-            return TextCommandResult.Success(UIUtils.I18n("Command.Info.Success", whisper, talk, shout, forceNameTags, encoding, wallThicknessWeighting));
+            return TextCommandResult.Success(UIUtils.I18n("Command.Info.Success", whisper, talk, shout, forceNameTags, encoding, wallThicknessWeighting, intoxicatedEffect));
         }
 
         private TextCommandResult SetWhisperHandler(TextCommandCallingArgs args)
@@ -205,6 +214,17 @@ namespace RPVoiceChat
             WorldConfig.Set("wall-thickness-weighting", weighting);
 
             return TextCommandResult.Success(UIUtils.I18n("Command.WallThicknessWeighting.Success", weighting));
+        }
+
+        private TextCommandResult ToggleIntoxicatedEffect(TextCommandCallingArgs args)
+        {
+            const string i18nPrefix = "Command.IntoxicatedEffect.Success";
+            bool state = (bool)args[0];
+
+            WorldConfig.Set("intoxicated-effect", state);
+
+            string stateAsText = state ? "Enabled" : "Disabled";
+            return TextCommandResult.Success(UIUtils.I18n($"{i18nPrefix}.{stateAsText}"));
         }
 
         public override void Dispose()


### PR DESCRIPTION
Resolves #19 
Create and apply  an intoxicated effect when a player is drunk (in-game !)
Fix also a potential bug on muffling effect