### PR TITLE
Range check optimization

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -5,7 +5,7 @@
   "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie", "RomainOdeval" ],
   "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash" ],
   "description": "A mod that adds in game voice proximity chat! Also bunch of in-game communication tools!",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "Side": "Universal",
   "RequiredOnClient": true,
   "RequiredOnServer": true,

--- a/src/Server/GameServer.cs
+++ b/src/Server/GameServer.cs
@@ -2,6 +2,7 @@ using RPVoiceChat.Config;
 using RPVoiceChat.Networking;
 using RPVoiceChat.Util;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Vintagestory.API.Common;
 using Vintagestory.API.Server;
@@ -21,7 +22,7 @@ namespace RPVoiceChat.Server
 
         // Stored players and their associated listeners
         private long listenerUpdateTickListener = 0;
-        private Dictionary<string, HashSet<IPlayer>> playerListeners = new Dictionary<string, HashSet<IPlayer>>();
+        private ConcurrentDictionary<string, HashSet<IPlayer>> playerListeners = new ConcurrentDictionary<string, HashSet<IPlayer>>();
 
         public GameServer(ICoreServerAPI sapi, List<INetworkServer> serverTransports)
         {
@@ -42,7 +43,7 @@ namespace RPVoiceChat.Server
         private void CalculateListenersForPlayers(float gameTick)
         {
             var allPlayers = api.World.AllOnlinePlayers;
-            var newListeners = new Dictionary<string, HashSet<IPlayer>>();
+            var newListeners = new ConcurrentDictionary<string, HashSet<IPlayer>>();
 
             foreach (IServerPlayer transmittingPlayer in allPlayers)
             {


### PR DESCRIPTION
Pulling the player range check out to run on the game thread every 500 ms rather than every packet transfer.

We may wanna verify this works with larger servers before making this properly a part of the mod.
I haven't been able to test other than just once with one other person.