### PR TITLE
RPVoiceChat 2.5.6

### DIFF
--- a/assets/rpvoicechat/patches/disabler/additional-content-blocks.json
+++ b/assets/rpvoicechat/patches/disabler/additional-content-blocks.json
@@ -138,5 +138,35 @@
       "when": "rpvoicechat:additional-content",
       "isValue": "false"
     }
+  },
+  {
+    "op": "add",
+    "path": "/enabled",
+    "value": false,
+    "file": "rpvoicechat:blocktypes/signallamp.json",
+    "condition": {
+      "when": "rpvoicechat:additional-content",
+      "isValue": "false"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/enabled",
+    "value": false,
+    "file": "rpvoicechat:blocktypes/clay/raw/lucerne.json",
+    "condition": {
+      "when": "rpvoicechat:additional-content",
+      "isValue": "false"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/enabled",
+    "value": false,
+    "file": "rpvoicechat:blocktypes/clay/fired/lucerne.json",
+    "condition": {
+      "when": "rpvoicechat:additional-content",
+      "isValue": "false"
+    }
   }
 ]

--- a/assets/rpvoicechat/patches/disabler/additional-content-recipes.json
+++ b/assets/rpvoicechat/patches/disabler/additional-content-recipes.json
@@ -149,5 +149,25 @@
       "isValue": "false"
     }
   },
+  {
+    "op": "add",
+    "path": "/enabled",
+    "value": false,
+    "file": "rpvoicechat:recipes/grid/signallamp.json",
+    "condition": {
+      "when": "rpvoicechat:additional-content",
+      "isValue": "false"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/enabled",
+    "value": false,
+    "file": "rpvoicechat:recipes/clayforming/lucerne.json",
+    "condition": {
+      "when": "rpvoicechat:additional-content",
+      "isValue": "false"
+    }
+  }
 ]
 

--- a/assets/rpvoicechat/patches/disabler/technology-content-recipes.json
+++ b/assets/rpvoicechat/patches/disabler/technology-content-recipes.json
@@ -178,5 +178,25 @@
       "when": "rpvoicechat:additional-content",
       "isValue": "false"
     }
+  },
+  {
+    "op": "add",
+    "path": "/enabled",
+    "value": false,
+    "file": "rpvoicechat:recipes/grid/switchboard.json",
+    "condition": {
+      "when": "rpvoicechat:technology-content",
+      "isValue": "false"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/enabled",
+    "value": false,
+    "file": "rpvoicechat:recipes/grid/switchboard.json",
+    "condition": {
+      "when": "rpvoicechat:additional-content",
+      "isValue": "false"
+    }
   }
 ]

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,7 +5,7 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie", "RodinPandarex" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash", "k1llo", "Alconchloe" ],
     "description": "A mod that adds in game voice proximity chat! Also bunch of in-game communication tools!",
-    "version": "2.5.5",
+    "version": "2.5.6",
     "Side": "Universal",
     "RequiredOnClient": true,
     "RequiredOnServer": true,

--- a/src/Gui/SwitchboardDialog.cs
+++ b/src/Gui/SwitchboardDialog.cs
@@ -12,13 +12,15 @@ using Vintagestory.API.Client;
 
 using Vintagestory.API.Config;
 
+using Vintagestory.API.MathTools;
+
 
 
 namespace RPVoiceChat.Gui
 
 {
 
-    public class GuiDialogSwitchboard : GuiDialog
+    public class GuiDialogSwitchboard : GuiDialogBlockEntity
 
     {
 
@@ -37,7 +39,8 @@ namespace RPVoiceChat.Gui
 
 
 
-        public GuiDialogSwitchboard(ICoreClientAPI capi, BlockEntitySwitchboard switchboard) : base(capi)
+        public GuiDialogSwitchboard(ICoreClientAPI capi, BlockEntitySwitchboard switchboard)
+            : base(UIUtils.I18n("Switchboard.Gui.Title"), switchboard.Pos, capi)
 
         {
 

--- a/src/Gui/TelegraphMenuDialog.cs
+++ b/src/Gui/TelegraphMenuDialog.cs
@@ -5,10 +5,11 @@ using System.Collections.Generic;
 using System.Reflection;
 using RPVoiceChat.Util;
 using Vintagestory.API.Client;
+using Vintagestory.API.MathTools;
 
 namespace RPVoiceChat.Gui
 {
-    public class TelegraphMenuDialog : GuiDialog
+    public class TelegraphMenuDialog : GuiDialogBlockEntity
     {
         private BlockEntityTelegraph telegraphBlock;
 
@@ -26,7 +27,8 @@ namespace RPVoiceChat.Gui
         private string pendingEndpointName = "";
         private bool? lastCanEditRouting;
 
-        public TelegraphMenuDialog(ICoreClientAPI capi, BlockEntityTelegraph telegraphBlock) : base(capi)
+        public TelegraphMenuDialog(ICoreClientAPI capi, BlockEntityTelegraph telegraphBlock)
+            : base(UIUtils.I18n("Telegraph.Gui.Title"), telegraphBlock.Pos, capi)
         {
             this.telegraphBlock = telegraphBlock;
         }

--- a/src/Gui/TelephoneMenuDialog.cs
+++ b/src/Gui/TelephoneMenuDialog.cs
@@ -3,10 +3,11 @@ using System.Reflection;
 using RPVoiceChat.GameContent.BlockEntity;
 using RPVoiceChat.Util;
 using Vintagestory.API.Client;
+using Vintagestory.API.MathTools;
 
 namespace RPVoiceChat.Gui
 {
-    public class TelephoneMenuDialog : GuiDialog
+    public class TelephoneMenuDialog : GuiDialogBlockEntity
     {
         private readonly BlockEntityTelephone telephoneBlock;
         private GuiElementTextInput numberInput;
@@ -20,7 +21,8 @@ namespace RPVoiceChat.Gui
         private bool managedBySwitchboard;
         private bool canEditManagedOptions;
 
-        public TelephoneMenuDialog(ICoreClientAPI capi, BlockEntityTelephone telephoneBlock) : base(capi)
+        public TelephoneMenuDialog(ICoreClientAPI capi, BlockEntityTelephone telephoneBlock)
+            : base(UIUtils.I18n("Telephone.Gui.Title"), telephoneBlock.Pos, capi)
         {
             this.telephoneBlock = telephoneBlock;
         }


### PR DESCRIPTION
fix: using VS vanilla GuidialogBlockEntity methods to close automatically GUIs if too far of telephone, telegraph key or switcboard
fix: lucerne/signal lamp disabled by "additional content" conf
fix: switchboard recipe disabled by "additional content" and "technology content" confs