### PR TITLE
RPVoiceChat 2.5.7

### DIFF
--- a/assets/rpvoicechat/blocktypes/churchbell-layer.json
+++ b/assets/rpvoicechat/blocktypes/churchbell-layer.json
@@ -26,7 +26,7 @@
   },
   "variantgroups": [
     {
-      "code": "material",
+      "code": "metal",
       "states": [ "brass" ]
     },
     {

--- a/assets/rpvoicechat/blocktypes/churchbell-part.json
+++ b/assets/rpvoicechat/blocktypes/churchbell-part.json
@@ -26,7 +26,7 @@
   },
   "variantgroups": [
     {
-      "code": "material",
+      "code": "metal",
       "states": [ "brass" ]
     },
     {

--- a/assets/rpvoicechat/blocktypes/clay/fired/churchbellmold.json
+++ b/assets/rpvoicechat/blocktypes/clay/fired/churchbellmold.json
@@ -19,7 +19,7 @@
       "fillQuadsByLevel": [ { "x1": 2, "z1": 2, "x2": 14, "z2": 8 } ],
       "moldrackable": true,
       "onmoldrackTransform": { "rotation": { "z": 90 } },
-      "drop": { "type": "Block", "code": "churchbell-{layer}", "quantity": 1 }
+      "drop": { "type": "Block", "code": "churchbell-part-{metal}-bottom", "quantity": 1 }
     },
     "churchbellmold-*-fired-part-brass-middle": {
       "requiredUnits": 300,
@@ -27,7 +27,7 @@
       "fillQuadsByLevel": [ { "x1": 2, "z1": 2, "x2": 14, "z2": 10 } ],
       "moldrackable": true,
       "onmoldrackTransform": { "rotation": { "z": 90 } },
-      "drop": { "type": "Block", "code": "churchbell-{layer}", "quantity": 1 }
+      "drop": { "type": "Block", "code": "churchbell-part-{metal}-middle", "quantity": 1 }
     },
     "churchbellmold-*-fired-part-brass-top": {
       "requiredUnits": 300,
@@ -35,7 +35,7 @@
       "fillQuadsByLevel": [ { "x1": 3, "z1": 2, "x2": 12, "z2": 14 } ],
       "moldrackable": true,
       "onmoldrackTransform": { "rotation": { "z": 90 } },
-      "drop": { "type": "Block", "code": "churchbell-{layer}", "quantity": 1 }
+      "drop": { "type": "Block", "code": "churchbell-part-{metal}-top", "quantity": 1 }
     },
     "churchbellmold-*-fired-layer-brass-topmost": {
       "requiredUnits": 300,
@@ -43,7 +43,7 @@
       "fillQuadsByLevel": [ { "x1": 4, "z1": 4, "x2": 13, "z2": 12 } ],
       "moldrackable": true,
       "onmoldrackTransform": { "rotation": { "z": 90 } },
-      "drop": { "type": "Block", "code": "churchbell-{layer}", "quantity": 1 }
+      "drop": { "type": "Block", "code": "churchbell-layer-{metal}-topmost", "quantity": 1 }
     }
   },
   "blockmaterial": "Ceramic",

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,7 +5,7 @@
     "authors": [ "Ridderrasmus", "Purplep_", "Dmitry221060", "Nixie", "RodinPandarex" ],
     "contributors": [ "Floffel", "blakdragan7", "Vlammar", "Kampftroll", "Nyuhnyash", "k1llo", "Alconchloe" ],
     "description": "A mod that adds in game voice proximity chat! Also bunch of in-game communication tools!",
-    "version": "2.5.6",
+    "version": "2.5.7",
     "Side": "Universal",
     "RequiredOnClient": true,
     "RequiredOnServer": true,

--- a/src/BlockEntity/BEWireNode.cs
+++ b/src/BlockEntity/BEWireNode.cs
@@ -169,19 +169,59 @@ namespace RPVoiceChat.GameContent.BlockEntity
                     var existing = WireNetworkHandler.GetNetwork(NetworkUID);
                     if (existing != null)
                     {
-                        existing.AddNode(this);
+                        if (!existing.Nodes.Contains(this))
+                        {
+                            existing.AddNode(this);
+                        }
+
                         WireNetworkHandler.PropagateNetworkUIDToConnectedNodes(this, existing);
                     }
-                    else if (IsNetworkRoot(this))
+                    else
                     {
-                        // Network was lost, recreate it
-                        WireNetworkHandler.AddNewNetwork(this);
+                        // Never mint a fresh id here: other chunks may still reference this serialized NetworkUID.
+                        // (FromTreeAttributes usually registers the shell first; this path recovers if load order skipped it.)
+                        EnsureRegisteredInNetworkFromSerializedId();
+                        var recovered = WireNetworkHandler.GetNetwork(NetworkUID);
+                        if (recovered != null)
+                        {
+                            WireNetworkHandler.PropagateNetworkUIDToConnectedNodes(this, recovered);
+                        }
                     }
                 }
             }
 
             ResolvePendingConnectionsAndNotify();
             EnsurePendingConnectionRetryListener();
+        }
+
+        /// <summary>
+        /// Ensures <see cref="WireNetworkHandler"/> has a <see cref="WireNetwork"/> keyed by <see cref="NetworkUID"/>
+        /// and that this node is registered on that instance. Always uses the serialized id as the network id
+        /// (does not allocate a new id like <see cref="WireNetworkHandler.AddNewNetwork"/>).
+        /// <para />
+        /// If <see cref="WireNetworkHandler.AddNetwork"/> is a no-op because another node already registered the same id,
+        /// attaches to the dictionary-backed network instead of the temporary shell object.
+        /// </summary>
+        private void EnsureRegisteredInNetworkFromSerializedId()
+        {
+            if (NetworkUID == 0)
+            {
+                return;
+            }
+
+            var shell = new WireNetwork { networkID = NetworkUID };
+            WireNetworkHandler.AddNetwork(shell);
+
+            var net = WireNetworkHandler.GetNetwork(NetworkUID);
+            if (net == null)
+            {
+                return;
+            }
+
+            if (!net.Nodes.Contains(this))
+            {
+                net.AddNode(this);
+            }
         }
 
         public void MarkForUpdate()
@@ -790,10 +830,7 @@ namespace RPVoiceChat.GameContent.BlockEntity
                 var existingNetwork = WireNetworkHandler.GetNetwork(NetworkUID);
                 if (existingNetwork == null)
                 {
-                    // Create the network (client-side or server-side)
-                    var restoredNetwork = new WireNetwork { networkID = NetworkUID };
-                    WireNetworkHandler.AddNetwork(restoredNetwork);
-                    restoredNetwork.AddNode(this);
+                    EnsureRegisteredInNetworkFromSerializedId();
                 }
                 else
                 {


### PR DESCRIPTION
fix(BEWireNode): Restore onto serialized network UID instead of spawning a new network when missing

fix:: Restrict church bell tool molds to brass pours